### PR TITLE
feat(fetch): add Jina Reader fetch provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ provider keys or create Trellis/hooks/agents/commands.
 | `main_search` | `search` | xAI Responses, OpenAI-compatible Chat Completions | Broad answer generation and synthesis |
 | `docs_search` | `context7-library`, `context7-docs`, `exa-search` | Context7, Exa | Official docs, SDKs, APIs, framework/library evidence |
 | `web_search` | `zhipu-search`, intent-routed reinforcement inside `search` | Zhipu, Tavily, Firecrawl | Chinese, domestic, current, domain-filtered, or supplementary web discovery |
-| `web_fetch` | `fetch` | Tavily, Firecrawl | Exact URL content extraction for evidence |
+| `web_fetch` | `fetch` | Jina Reader, Tavily, Firecrawl | Exact URL content extraction for evidence |
 | `vertical_search` | `anysearch-domains`, `anysearch-search`, `anysearch-extract`, `anysearch-batch` | AnySearch (experimental) | Acceptance testing for structured vertical domains such as CVE, finance, legal, academic, and code/docs |
 | `site_map` | `map` | Tavily | Site/documentation structure discovery |
 | `deep_planner` | `deep` / `dr` | Local planner only | Offline plan generation; no provider call by default |
@@ -129,7 +129,7 @@ Fallback is same-capability only:
 | `main_search` | xAI Responses -> OpenAI-compatible |
 | `docs_search` | Context7 for library/API/docs intent; Exa for official domains, papers, product pages, and trusted-site discovery |
 | `web_search` | Zhipu -> Tavily -> Firecrawl |
-| `web_fetch` | Tavily -> Firecrawl |
+| `web_fetch` | Jina Reader -> Tavily -> Firecrawl |
 
 AnySearch is intentionally not part of the `web_search` fallback chain and is not required by the `standard` minimum profile. Use its explicit commands for acceptance and boundary testing before promoting any vertical domain into a future route.
 
@@ -195,7 +195,8 @@ Use `smart-search setup` for normal configuration. Environment variables remain 
 | Exa | Low-noise official docs, API, paper, product, trusted-page discovery | `EXA_API_KEY` | [Exa docs](https://docs.exa.ai/) | [Exa API keys](https://dashboard.exa.ai/api-keys) |
 | Context7 | SDK, library, framework, and API documentation fallback | `CONTEXT7_API_KEY`, `CONTEXT7_BASE_URL` | [Context7 docs](https://context7.com/docs) | [Context7](https://context7.com/) |
 | Zhipu Web Search API | Chinese, domestic, current, or domain-filtered web discovery | `ZHIPU_API_KEY`, `ZHIPU_API_URL`, `ZHIPU_SEARCH_ENGINE` | [Zhipu web search docs](https://docs.bigmodel.cn/cn/guide/tools/web-search) | [Zhipu API keys](https://open.bigmodel.cn/usercenter/apikeys) |
-| Tavily | Extra web sources, URL fetch, and site map | `TAVILY_API_URL`, `TAVILY_API_KEY` | [Tavily docs](https://docs.tavily.com/) | [Tavily app](https://app.tavily.com/home) |
+| Jina Reader | Default URL fetch; anonymous basic mode works without a key, `readerlm-v2` requires `JINA_API_KEY` and explicit `JINA_RESPOND_WITH=readerlm-v2` | `JINA_API_KEY`, `JINA_READER_API_URL`, `JINA_RESPOND_WITH` | [Jina Reader API](https://jina.ai/reader/) | [Jina API keys](https://jina.ai/) |
+| Tavily | Extra web sources, URL fetch fallback, and site map | `TAVILY_API_URL`, `TAVILY_API_KEY` | [Tavily docs](https://docs.tavily.com/) | [Tavily app](https://app.tavily.com/home) |
 | Firecrawl | Fetch fallback and supplementary web sources | `FIRECRAWL_API_URL`, `FIRECRAWL_API_KEY` | [Firecrawl docs](https://docs.firecrawl.dev/) | [Firecrawl API keys](https://www.firecrawl.dev/app/api-keys) |
 | AnySearch | Experimental vertical search acceptance surface; not a default fallback | `ANYSEARCH_API_URL`, `ANYSEARCH_API_KEY`, `ANYSEARCH_TIMEOUT_SECONDS` | Provider documentation | AnySearch dashboard / provider console |
 
@@ -209,6 +210,13 @@ Important boundaries:
 - `ZHIPU_SEARCH_ENGINE` defaults to `search_std`. Supported official values include `search_std`, `search_pro`, `search_pro_sogou`, and `search_pro_quark`; custom values remain allowed for future services.
 - `TAVILY_API_URL` affects Tavily only. It does not proxy Zhipu. For Tavily Hikari / pooled endpoints, use `https://<host>/api/tavily`; setup normalizes root-host or `/mcp` inputs to that REST base.
 - `FIRECRAWL_API_URL` defaults to `https://api.firecrawl.dev/v2`.
+
+Jina Reader notes:
+
+- Basic `r.jina.ai` fetch works anonymously and is the default first `web_fetch` attempt.
+- `JINA_API_KEY` raises Jina rate limits but does not automatically enable model-based conversion.
+- `JINA_RESPOND_WITH=readerlm-v2` opts into ReaderLM-v2. This requires `JINA_API_KEY`, can be slower and more costly, and is intended for explicit high-quality conversion experiments rather than default evidence fetching.
+
 - AnySearch uses JSON-RPC 2.0 `tools/call` at `https://api.anysearch.com/mcp` by default. It allows anonymous calls when no key is configured, but authenticated calls send `Authorization: Bearer ...`. HTTP 200 responses with `result.isError=true` are treated as provider errors, not as successful evidence.
 
 Non-interactive setup example:
@@ -229,6 +237,9 @@ smart-search setup --non-interactive `
   --zhipu-key "your-zhipu-key" `
   --zhipu-api-url "https://open.bigmodel.cn/api" `
   --zhipu-search-engine "search_pro_sogou" `
+  --jina-reader-api-url "https://r.jina.ai" `
+  --jina-key "optional-jina-key" `
+  --jina-respond-with "" `
   --tavily-api-url "https://api.tavily.com" `
   --tavily-key "your-tavily-key" `
   --firecrawl-api-url "https://api.firecrawl.dev/v2" `
@@ -239,7 +250,7 @@ Minimum profile defaults to `standard`, requiring at least:
 
 - one `main_search` provider: xAI Responses or OpenAI-compatible;
 - one `docs_search` provider: Exa or Context7;
-- one `web_fetch` provider: Tavily or Firecrawl.
+- one `web_fetch` provider: Jina Reader, Tavily, or Firecrawl. Jina Reader basic mode is available without an API key, so `web_fetch` can be satisfied by default unless you disable the standard minimum profile for experiments.
 
 Missing required capabilities fail closed with a configuration error. Use `SMART_SEARCH_MINIMUM_PROFILE=off` only for local experiments.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -110,7 +110,7 @@ Trellis、hooks、agents 或 commands。
 | `main_search` | `search` | xAI Responses、OpenAI-compatible Chat Completions | 综合回答、快速搜索、初步总结 |
 | `docs_search` | `context7-library`、`context7-docs`、`exa-search` | Context7、Exa | 官方文档、SDK、API、框架/库文档 |
 | `web_search` | `zhipu-search`、`search` 内部意图补强 | 智谱、Tavily、Firecrawl | 中文、国内、时效、域名过滤、补充来源 |
-| `web_fetch` | `fetch` | Tavily、Firecrawl | 已知 URL 正文抓取、证据提取 |
+| `web_fetch` | `fetch` | Jina Reader、Tavily、Firecrawl | 已知 URL 正文抓取、证据提取 |
 | `vertical_search` | `anysearch-domains`、`anysearch-search`、`anysearch-extract`、`anysearch-batch` | AnySearch（实验） | 验收 CVE、金融、法律、学术、代码/文档等结构化垂直域 |
 | `site_map` | `map` | Tavily | 文档站、产品站、目录型站点结构 |
 | `deep_planner` | `deep` / `dr` | 本地 planner | 离线生成 Deep Research 计划，不默认联网 |
@@ -122,7 +122,7 @@ Trellis、hooks、agents 或 commands。
 | `main_search` | xAI Responses -> OpenAI-compatible |
 | `docs_search` | Context7 处理库/API/文档意图；Exa 处理官方域名、论文、产品页、可信站点发现 |
 | `web_search` | 智谱 -> Tavily -> Firecrawl |
-| `web_fetch` | Tavily -> Firecrawl |
+| `web_fetch` | Jina Reader -> Tavily -> Firecrawl |
 
 AnySearch 当前只作为实验 `vertical_search` 暴露，不进入 `web_search` 兜底链，也不是 `standard` 最低配置要求。请先用显式命令做验收和能力边界判断，再决定未来是否把某个垂直域提升成正式路线。
 
@@ -204,7 +204,8 @@ smart-search deep "https://example.com/source" --format json
 | Exa | 官方文档、API、论文、产品页、可信网页的低噪声发现 | `EXA_API_KEY` | [Exa docs](https://docs.exa.ai/) | [Exa API keys](https://dashboard.exa.ai/api-keys) |
 | Context7 | SDK、库、框架、API 文档兜底 | `CONTEXT7_API_KEY`、`CONTEXT7_BASE_URL` | [Context7 docs](https://context7.com/docs) | [Context7](https://context7.com/) |
 | 智谱 Web Search API | 中文、国内、时效、域名过滤类来源发现 | `ZHIPU_API_KEY`、`ZHIPU_API_URL`、`ZHIPU_SEARCH_ENGINE` | [智谱联网搜索文档](https://docs.bigmodel.cn/cn/guide/tools/web-search) | [智谱 API keys](https://open.bigmodel.cn/usercenter/apikeys) |
-| Tavily | 额外来源、URL fetch、站点 map | `TAVILY_API_URL`、`TAVILY_API_KEY` | [Tavily docs](https://docs.tavily.com/) | [Tavily app](https://app.tavily.com/home) |
+| Jina Reader | 默认 URL fetch；基础模式可匿名使用，`readerlm-v2` 需要 `JINA_API_KEY` 并显式设置 `JINA_RESPOND_WITH=readerlm-v2` | `JINA_API_KEY`、`JINA_READER_API_URL`、`JINA_RESPOND_WITH` | [Jina Reader API](https://jina.ai/reader/) | [Jina API keys](https://jina.ai/) |
+| Tavily | 额外来源、URL fetch 兜底、站点 map | `TAVILY_API_URL`、`TAVILY_API_KEY` | [Tavily docs](https://docs.tavily.com/) | [Tavily app](https://app.tavily.com/home) |
 | Firecrawl | fetch 兜底、补充网页来源 | `FIRECRAWL_API_URL`、`FIRECRAWL_API_KEY` | [Firecrawl docs](https://docs.firecrawl.dev/) | [Firecrawl API keys](https://www.firecrawl.dev/app/api-keys) |
 | AnySearch | 实验垂直搜索验收入口，不是默认兜底 | `ANYSEARCH_API_URL`、`ANYSEARCH_API_KEY`、`ANYSEARCH_TIMEOUT_SECONDS` | 服务商文档 | AnySearch 控制台 / 服务商控制台 |
 
@@ -218,6 +219,13 @@ smart-search deep "https://example.com/source" --format json
 - `ZHIPU_SEARCH_ENGINE` 默认是 `search_std`。官方值包括 `search_std`、`search_pro`、`search_pro_sogou`、`search_pro_quark`；`config set` 仍允许自定义值，方便官方以后新增服务。
 - `TAVILY_API_URL` 只影响 Tavily，不会代理智谱。Tavily Hikari / 号池用 `https://<host>/api/tavily`；setup 会把根域名或 `/mcp` 输入规范化成这个 REST base。
 - `FIRECRAWL_API_URL` 默认是 `https://api.firecrawl.dev/v2`。
+
+Jina Reader 注意点：
+
+- 基础 `r.jina.ai` fetch 可匿名使用，并作为默认第一个 `web_fetch` 尝试。
+- `JINA_API_KEY` 用于提高 Jina 限额，但不会自动启用模型转换。
+- `JINA_RESPOND_WITH=readerlm-v2` 会显式启用 ReaderLM-v2；它需要 `JINA_API_KEY`，速度更慢、成本更高，适合明确的高质量转换实验，不适合作为默认证据抓取。
+
 - AnySearch 默认走 `https://api.anysearch.com/mcp` 的 JSON-RPC 2.0 `tools/call`。没有 key 时允许匿名请求；有 key 时发送 `Authorization: Bearer ...`。HTTP 200 但 `result.isError=true` 会按 provider error 处理，不能当成功证据。
 
 非交互配置示例：
@@ -238,6 +246,9 @@ smart-search setup --non-interactive `
   --zhipu-key "your-zhipu-key" `
   --zhipu-api-url "https://open.bigmodel.cn/api" `
   --zhipu-search-engine "search_pro_sogou" `
+  --jina-reader-api-url "https://r.jina.ai" `
+  --jina-key "optional-jina-key" `
+  --jina-respond-with "" `
   --tavily-api-url "https://api.tavily.com" `
   --tavily-key "your-tavily-key" `
   --firecrawl-api-url "https://api.firecrawl.dev/v2" `
@@ -248,7 +259,7 @@ smart-search setup --non-interactive `
 
 - `main_search`：xAI Responses 或 OpenAI-compatible 二选一；
 - `docs_search`：Exa 或 Context7 二选一；
-- `web_fetch`：Tavily 或 Firecrawl 二选一。
+- `web_fetch`：Jina Reader、Tavily 或 Firecrawl。Jina Reader 基础模式可匿名使用，因此默认即可满足 `web_fetch` 能力；如需实验可关闭 standard minimum profile。
 
 缺少任一最低能力时，`doctor` 和 `search` 会 fail closed 并返回缺失 capability。`SMART_SEARCH_MINIMUM_PROFILE=off` 只建议本地实验使用。
 

--- a/skills/smart-search-cli/SKILL.md
+++ b/skills/smart-search-cli/SKILL.md
@@ -143,7 +143,7 @@ smart-search deep "https://example.com/source" --format json
 - Legacy `SMART_SEARCH_API_URL`, `SMART_SEARCH_API_KEY`, `SMART_SEARCH_API_MODE`, `SMART_SEARCH_MODEL`, and `SMART_SEARCH_XAI_TOOLS` are unsupported config keys.
 - xAI Responses mode may use only `XAI_TOOLS=web_search,x_search` and a subset of those tools.
 - Chat Completions mode must not send xAI `web_search` / `x_search` tools or legacy `search_parameters`; xAI Chat Completions Live Search is deprecated.
-- The standard minimum profile requires one configured provider in each of `main_search`, `docs_search`, and fetch capability. Missing required capabilities should be treated as a hard configuration failure.
+- The standard minimum profile requires one configured provider in each of `main_search`, `docs_search`, and fetch capability; Jina Reader basic fetch is available without a key. Missing required capabilities should be treated as a hard configuration failure.
 - AnySearch is reported only as optional experimental `vertical_search`; it is not part of the `web_search` fallback and is not required by the `standard` minimum profile.
 - `search` exposes `--validation fast|balanced|strict`, `--fallback auto|off`, and `--providers auto|CSV`. Default validation is `balanced`; fallback only happens within the same capability.
 - xAI Responses is the default main answer route for Grok/xAI. In `fallback=auto`, a failed xAI Responses main route can fall back to OpenAI-compatible only when the OpenAI-compatible provider is separately configured.
@@ -153,7 +153,7 @@ smart-search deep "https://example.com/source" --format json
 - With both Tavily and Firecrawl configured, `search --extra-sources N` splits extra sources between them, with Tavily receiving about 60% and Firecrawl the rest.
 - Search JSON separates `primary_sources`, `extra_sources`, and backward-compatible merged `sources`.
 - `primary_sources` are extracted from the primary model answer. `extra_sources` are parallel Tavily / Firecrawl candidates and are not automatically used to verify `content`.
-- `fetch` tries Tavily first and uses Firecrawl only as a fallback when Tavily returns no content.
+- `fetch` tries Jina Reader first, then Tavily, then Firecrawl. Jina basic Reader works without a key; ReaderLM-v2 requires `JINA_API_KEY` and explicit `JINA_RESPOND_WITH=readerlm-v2`.
 - `map` currently uses Tavily only.
 - `exa-search` and `exa-similar` use Exa only.
 - `context7-library` and `context7-docs` use Context7 only.

--- a/skills/smart-search-cli/references/cli-contract.md
+++ b/skills/smart-search-cli/references/cli-contract.md
@@ -304,11 +304,11 @@ Agent timeout handling contract:
 - `main_search`: xAI Responses first for Grok/xAI, then OpenAI-compatible answer fallback when that peer provider is separately configured and `--fallback auto` is active.
 - `web_search`: Zhipu first when routed in, then Tavily / Firecrawl source search when configured.
 - `docs_search`: Context7 first for library/API/docs intent, then Exa for official-domain, paper, product-page, trusted-site, or low-noise supplemental discovery.
-- Fetch capability: Tavily first, then Firecrawl.
+- Fetch capability: Jina Reader first, then Tavily, then Firecrawl.
 - `search` calls Tavily and/or Firecrawl only when `--extra-sources` is greater than 0.
 - If both Tavily and Firecrawl are configured, `search --extra-sources N` gives about 60% of extra source slots to Tavily and the remainder to Firecrawl.
 - `extra_sources` are retrieved in parallel and are not automatically used by the primary model to verify its answer.
-- `fetch` tries Tavily first, then Firecrawl as fallback when Tavily returns no content.
+- `fetch` tries Jina Reader first, then Tavily, then Firecrawl as fallbacks when prior providers return no content.
 - `map` uses Tavily only.
 - `exa-search` and `exa-similar` use Exa only.
 - `zhipu-search` uses Zhipu only.

--- a/src/smart_search/assets/skills/smart-search-cli/SKILL.md
+++ b/src/smart_search/assets/skills/smart-search-cli/SKILL.md
@@ -143,7 +143,7 @@ smart-search deep "https://example.com/source" --format json
 - Legacy `SMART_SEARCH_API_URL`, `SMART_SEARCH_API_KEY`, `SMART_SEARCH_API_MODE`, `SMART_SEARCH_MODEL`, and `SMART_SEARCH_XAI_TOOLS` are unsupported config keys.
 - xAI Responses mode may use only `XAI_TOOLS=web_search,x_search` and a subset of those tools.
 - Chat Completions mode must not send xAI `web_search` / `x_search` tools or legacy `search_parameters`; xAI Chat Completions Live Search is deprecated.
-- The standard minimum profile requires one configured provider in each of `main_search`, `docs_search`, and fetch capability. Missing required capabilities should be treated as a hard configuration failure.
+- The standard minimum profile requires one configured provider in each of `main_search`, `docs_search`, and fetch capability; Jina Reader basic fetch is available without a key. Missing required capabilities should be treated as a hard configuration failure.
 - AnySearch is reported only as optional experimental `vertical_search`; it is not part of the `web_search` fallback and is not required by the `standard` minimum profile.
 - `search` exposes `--validation fast|balanced|strict`, `--fallback auto|off`, and `--providers auto|CSV`. Default validation is `balanced`; fallback only happens within the same capability.
 - xAI Responses is the default main answer route for Grok/xAI. In `fallback=auto`, a failed xAI Responses main route can fall back to OpenAI-compatible only when the OpenAI-compatible provider is separately configured.
@@ -153,7 +153,7 @@ smart-search deep "https://example.com/source" --format json
 - With both Tavily and Firecrawl configured, `search --extra-sources N` splits extra sources between them, with Tavily receiving about 60% and Firecrawl the rest.
 - Search JSON separates `primary_sources`, `extra_sources`, and backward-compatible merged `sources`.
 - `primary_sources` are extracted from the primary model answer. `extra_sources` are parallel Tavily / Firecrawl candidates and are not automatically used to verify `content`.
-- `fetch` tries Tavily first and uses Firecrawl only as a fallback when Tavily returns no content.
+- `fetch` tries Jina Reader first, then Tavily, then Firecrawl. Jina basic Reader works without a key; ReaderLM-v2 requires `JINA_API_KEY` and explicit `JINA_RESPOND_WITH=readerlm-v2`.
 - `map` currently uses Tavily only.
 - `exa-search` and `exa-similar` use Exa only.
 - `context7-library` and `context7-docs` use Context7 only.

--- a/src/smart_search/assets/skills/smart-search-cli/references/cli-contract.md
+++ b/src/smart_search/assets/skills/smart-search-cli/references/cli-contract.md
@@ -304,11 +304,11 @@ Agent timeout handling contract:
 - `main_search`: xAI Responses first for Grok/xAI, then OpenAI-compatible answer fallback when that peer provider is separately configured and `--fallback auto` is active.
 - `web_search`: Zhipu first when routed in, then Tavily / Firecrawl source search when configured.
 - `docs_search`: Context7 first for library/API/docs intent, then Exa for official-domain, paper, product-page, trusted-site, or low-noise supplemental discovery.
-- Fetch capability: Tavily first, then Firecrawl.
+- Fetch capability: Jina Reader first, then Tavily, then Firecrawl.
 - `search` calls Tavily and/or Firecrawl only when `--extra-sources` is greater than 0.
 - If both Tavily and Firecrawl are configured, `search --extra-sources N` gives about 60% of extra source slots to Tavily and the remainder to Firecrawl.
 - `extra_sources` are retrieved in parallel and are not automatically used by the primary model to verify its answer.
-- `fetch` tries Tavily first, then Firecrawl as fallback when Tavily returns no content.
+- `fetch` tries Jina Reader first, then Tavily, then Firecrawl as fallbacks when prior providers return no content.
 - `map` uses Tavily only.
 - `exa-search` and `exa-similar` use Exa only.
 - `zhipu-search` uses Zhipu only.

--- a/src/smart_search/cli.py
+++ b/src/smart_search/cli.py
@@ -1134,12 +1134,13 @@ def _setup_status_from_values(values: dict[str, str]) -> dict[str, Any]:
             "configured": [
                 provider
                 for provider, configured in [
+                    ("jina", True),
                     ("tavily", has("TAVILY_API_KEY")),
                     ("firecrawl", has("FIRECRAWL_API_KEY")),
                 ]
                 if configured
             ],
-            "fallback_chain": ["tavily", "firecrawl"],
+            "fallback_chain": ["jina", "tavily", "firecrawl"],
         },
         "vertical_search": {
             "configured": ["anysearch"] if has("ANYSEARCH_API_KEY") else [],
@@ -1658,6 +1659,12 @@ def _prompt_zhipu_search_engine(values: dict[str, str], current: dict[str, str],
     values["ZHIPU_SEARCH_ENGINE"] = choice
 
 
+def _prompt_jina(values: dict[str, str], current: dict[str, str], lang: str) -> None:
+    values["JINA_API_KEY"] = _prompt_value("JINA_API_KEY", "Jina API key", current.get("JINA_API_KEY", ""), optional=True, lang=lang)
+    values["JINA_READER_API_URL"] = _prompt_value("JINA_READER_API_URL", "Jina Reader API URL", current.get("JINA_READER_API_URL", "https://r.jina.ai"), optional=True, lang=lang)
+    values["JINA_RESPOND_WITH"] = _prompt_value("JINA_RESPOND_WITH", "Jina respond-with mode (optional, e.g. readerlm-v2)", current.get("JINA_RESPOND_WITH", ""), optional=True, lang=lang)
+
+
 def _prompt_web_fetch(values: dict[str, str], current: dict[str, str], lang: str) -> None:
     status = _setup_status_from_values(_merge_setup_values(current, values))
     default_selected = status["web_fetch"]["configured"] or ["tavily"]
@@ -1834,6 +1841,9 @@ def _run_advanced_setup_prompts(values: dict[str, str], current: dict[str, str],
         ("ZHIPU_API_KEY", "Zhipu API key", True),
         ("ZHIPU_API_URL", "Zhipu Web Search API URL", True),
         ("ZHIPU_SEARCH_ENGINE", "Zhipu search service (search_std/search_pro/search_pro_sogou/search_pro_quark/custom)", True),
+        ("JINA_API_KEY", "Jina API key", True),
+        ("JINA_READER_API_URL", "Jina Reader API URL", True),
+        ("JINA_RESPOND_WITH", "Jina respond-with mode (optional, e.g. readerlm-v2)", True),
         ("TAVILY_API_URL", "Tavily API URL", True),
         ("TAVILY_API_KEY", "Tavily API key", True),
         ("FIRECRAWL_API_URL", "Firecrawl API URL", True),
@@ -2046,6 +2056,9 @@ def _run_setup(args: argparse.Namespace) -> int:
         "ZHIPU_API_KEY": args.zhipu_key,
         "ZHIPU_API_URL": _normalize_zhipu_api_url(args.zhipu_api_url),
         "ZHIPU_SEARCH_ENGINE": args.zhipu_search_engine,
+        "JINA_API_KEY": args.jina_key,
+        "JINA_READER_API_URL": args.jina_reader_api_url,
+        "JINA_RESPOND_WITH": args.jina_respond_with,
         "TAVILY_API_URL": _normalize_tavily_flag_api_url(args.tavily_api_url, args.tavily_key),
         "TAVILY_API_KEY": args.tavily_key,
         "FIRECRAWL_API_URL": _normalize_firecrawl_api_url(args.firecrawl_api_url),
@@ -2398,6 +2411,9 @@ def build_parser() -> argparse.ArgumentParser:
     setup_parser.add_argument("--zhipu-key", default="", help="Save ZHIPU_API_KEY.")
     setup_parser.add_argument("--zhipu-api-url", default="", help="Save ZHIPU_API_URL.")
     setup_parser.add_argument("--zhipu-search-engine", default="", help="Save ZHIPU_SEARCH_ENGINE.")
+    setup_parser.add_argument("--jina-key", default="", help="Save JINA_API_KEY.")
+    setup_parser.add_argument("--jina-reader-api-url", default="", help="Save JINA_READER_API_URL.")
+    setup_parser.add_argument("--jina-respond-with", default="", help="Save JINA_RESPOND_WITH, e.g. readerlm-v2 (requires JINA_API_KEY).")
     setup_parser.add_argument("--tavily-api-url", default="", help="Save TAVILY_API_URL.")
     setup_parser.add_argument("--tavily-key", default="", help="Save TAVILY_API_KEY.")
     setup_parser.add_argument("--firecrawl-api-url", default="", help="Save FIRECRAWL_API_URL.")

--- a/src/smart_search/config.py
+++ b/src/smart_search/config.py
@@ -47,6 +47,9 @@ class Config:
         "TAVILY_TIMEOUT_SECONDS",
         "FIRECRAWL_API_KEY",
         "FIRECRAWL_API_URL",
+        "JINA_API_KEY",
+        "JINA_READER_API_URL",
+        "JINA_RESPOND_WITH",
         "ANYSEARCH_API_KEY",
         "ANYSEARCH_API_URL",
         "ANYSEARCH_TIMEOUT_SECONDS",
@@ -395,6 +398,18 @@ class Config:
     @property
     def firecrawl_api_key(self) -> str | None:
         return self._get_config_value("FIRECRAWL_API_KEY")
+
+    @property
+    def jina_api_key(self) -> str | None:
+        return self._get_config_value("JINA_API_KEY")
+
+    @property
+    def jina_reader_api_url(self) -> str:
+        return self._get_config_value("JINA_READER_API_URL", "https://r.jina.ai") or "https://r.jina.ai"
+
+    @property
+    def jina_respond_with(self) -> str:
+        return self._get_config_value("JINA_RESPOND_WITH", "") or ""
 
     @property
     def anysearch_api_url(self) -> str:

--- a/src/smart_search/service.py
+++ b/src/smart_search/service.py
@@ -667,12 +667,13 @@ def get_capability_status() -> dict[str, Any]:
             "configured": [
                 name
                 for name, enabled in [
+                    ("jina", True),
                     ("tavily", bool(config.tavily_api_key)),
                     ("firecrawl", bool(config.firecrawl_api_key)),
                 ]
                 if enabled
             ],
-            "fallback_chain": ["tavily", "firecrawl"],
+            "fallback_chain": ["jina", "tavily", "firecrawl"],
         },
         "vertical_search": {
             "configured": ["anysearch"] if config.anysearch_api_key else [],
@@ -998,6 +999,30 @@ async def _run_docs_search_fallback(
         except Exception as e:
             attempts.append(_attempt("docs_search", provider, "error", start, error_type="runtime_error", error=str(e)))
     return [], attempts
+
+
+async def call_jina_reader(url: str) -> str | None:
+    api_key = config.jina_api_key
+    base_url = config.jina_reader_api_url.rstrip("/")
+    endpoint = f"{base_url}/{url}"
+    headers = {"X-Return-Format": "markdown"}
+    respond_with = config.jina_respond_with.strip()
+    if respond_with and api_key:
+        headers["X-Respond-With"] = respond_with
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+
+    try:
+        async with httpx.AsyncClient(timeout=60.0, follow_redirects=True) as client:
+            response = await client.get(endpoint, headers=headers)
+            if response.status_code == 200:
+                content = response.text
+                return content if content and content.strip() else None
+            await log_info(None, f"Jina Reader HTTP {response.status_code}: {response.text[:200]}", config.debug_enabled)
+            return None
+    except Exception as e:
+        await log_info(None, f"Jina Reader error: {e}", config.debug_enabled)
+        return None
 
 
 async def call_tavily_extract(url: str) -> str | None:
@@ -1446,6 +1471,22 @@ def _primary_search_error_result(
 async def fetch(url: str) -> dict[str, Any]:
     start = time.time()
     attempts: list[dict] = []
+
+    jina_start = time.time()
+    jina_result = await call_jina_reader(url)
+    if jina_result:
+        attempts.append(_attempt("web_fetch", "jina", "ok", jina_start, result_count=1))
+        return {
+            "ok": True,
+            "url": url,
+            "provider": "jina",
+            "content": jina_result,
+            "provider_attempts": attempts,
+            "fallback_used": False,
+            "elapsed_ms": _elapsed_ms(start),
+        }
+    attempts.append(_attempt("web_fetch", "jina", "empty", jina_start))
+
     tavily_start = time.time()
     tavily_result = await call_tavily_extract(url)
     if tavily_result:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -356,7 +356,7 @@ def test_doctor_markdown_outputs_human_health_report(monkeypatch, capsys):
             "capability_status": {
                 "main_search": {"ok": True, "configured": ["openai-compatible"], "fallback_chain": ["xai-responses", "openai-compatible"]},
                 "docs_search": {"ok": True, "configured": ["context7"], "fallback_chain": ["context7", "exa"]},
-                "web_fetch": {"ok": True, "configured": ["tavily"], "fallback_chain": ["tavily", "firecrawl"]},
+                "web_fetch": {"ok": True, "configured": ["jina", "tavily"], "fallback_chain": ["jina", "tavily", "firecrawl"]},
             },
             "main_search_connection_tests": {
                 "openai-compatible": {
@@ -1712,7 +1712,7 @@ def test_setup_guided_en_reports_missing_minimum(monkeypatch, capsys):
     assert code == cli.EXIT_OK
     assert saved == {}
     assert data["minimum_profile_ok"] is False
-    assert data["minimum_profile_missing"] == ["main_search", "docs_search", "web_fetch"]
+    assert data["minimum_profile_missing"] == ["main_search", "docs_search"]
     assert "Smart Search setup wizard" in captured.err
     assert "If unsure" in captured.err
     assert "main_search + docs_search + web_fetch" in captured.err
@@ -1768,7 +1768,7 @@ def test_setup_guided_main_search_can_save_openai_compatible_peer(monkeypatch, c
         "OPENAI_COMPATIBLE_API_KEY": "relay-test-secret",
     }
     assert data["capability_status"]["main_search"]["configured"] == ["openai-compatible"]
-    assert data["minimum_profile_missing"] == ["docs_search", "web_fetch"]
+    assert data["minimum_profile_missing"] == ["docs_search"]
     assert "relay-test-secret" not in captured.out
     assert "relay-test-secret" not in captured.err
 

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -725,12 +725,16 @@ async def test_search_reports_primary_provider_http_error(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_fetch_prefers_tavily(monkeypatch):
+    async def no_jina(url):
+        return None
+
     async def yes_tavily(url):
         return "# Tavily Page"
 
     async def no_firecrawl(url, ctx=None):
         raise AssertionError("Firecrawl should not run when Tavily succeeds")
 
+    monkeypatch.setattr(service, "call_jina_reader", no_jina)
     monkeypatch.setattr(service, "call_tavily_extract", yes_tavily)
     monkeypatch.setattr(service, "call_firecrawl_scrape", no_firecrawl)
 
@@ -743,12 +747,16 @@ async def test_fetch_prefers_tavily(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_fetch_fallbacks_to_firecrawl(monkeypatch):
+    async def no_jina(url):
+        return None
+
     async def no_tavily(url):
         return None
 
     async def yes_firecrawl(url, ctx=None):
         return "# Page"
 
+    monkeypatch.setattr(service, "call_jina_reader", no_jina)
     monkeypatch.setattr(service, "call_tavily_extract", no_tavily)
     monkeypatch.setattr(service, "call_firecrawl_scrape", yes_firecrawl)
 
@@ -764,12 +772,16 @@ async def test_fetch_reports_config_error_without_extract_keys(monkeypatch):
     monkeypatch.delenv("TAVILY_API_KEY", raising=False)
     monkeypatch.delenv("FIRECRAWL_API_KEY", raising=False)
 
+    async def no_jina(url):
+        return None
+
     async def no_tavily(url):
         return None
 
     async def no_firecrawl(url, ctx=None):
         return None
 
+    monkeypatch.setattr(service, "call_jina_reader", no_jina)
     monkeypatch.setattr(service, "call_tavily_extract", no_tavily)
     monkeypatch.setattr(service, "call_firecrawl_scrape", no_firecrawl)
 
@@ -784,12 +796,16 @@ async def test_fetch_reports_network_error_when_providers_fail(monkeypatch):
     monkeypatch.setenv("TAVILY_API_KEY", "tavily-secret")
     monkeypatch.setenv("FIRECRAWL_API_KEY", "firecrawl-secret")
 
+    async def no_jina(url):
+        return None
+
     async def no_tavily(url):
         return None
 
     async def no_firecrawl(url, ctx=None):
         return None
 
+    monkeypatch.setattr(service, "call_jina_reader", no_jina)
     monkeypatch.setattr(service, "call_tavily_extract", no_tavily)
     monkeypatch.setattr(service, "call_firecrawl_scrape", no_firecrawl)
 

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -9,7 +9,7 @@ def test_minimum_profile_reports_missing_categories(monkeypatch):
     result = service.validate_minimum_profile()
 
     assert result["ok"] is False
-    assert set(result["missing"]) == {"main_search", "docs_search", "web_fetch"}
+    assert set(result["missing"]) == {"main_search", "docs_search"}
     assert "capability_status" in result
 
 
@@ -78,7 +78,7 @@ async def test_live_smoke_treats_provider_failure_as_degraded_when_fallback_exis
                 "main_search": {"configured": ["xai-responses"], "fallback_chain": ["xai-responses", "openai-compatible"], "ok": True},
                 "web_search": {"configured": ["zhipu", "tavily"], "fallback_chain": ["zhipu", "tavily", "firecrawl"], "ok": True},
                 "docs_search": {"configured": ["context7"], "fallback_chain": ["context7", "exa"], "ok": True},
-                "web_fetch": {"configured": ["tavily"], "fallback_chain": ["tavily", "firecrawl"], "ok": True},
+                "web_fetch": {"configured": ["jina", "tavily"], "fallback_chain": ["jina", "tavily", "firecrawl"], "ok": True},
             },
             "zhipu_connection_test": {"status": "warning", "message": "HTTP 429: Too Many Requests"},
             "context7_connection_test": {"status": "not_configured", "message": "CONTEXT7_API_KEY 未设置"},
@@ -102,12 +102,16 @@ async def test_fetch_attempts_show_fallback(monkeypatch):
     monkeypatch.setenv("TAVILY_API_KEY", "tavily-secret")
     monkeypatch.setenv("FIRECRAWL_API_KEY", "firecrawl-secret")
 
+    async def no_jina(url):
+        return None
+
     async def no_tavily(url):
         return None
 
     async def yes_firecrawl(url, ctx=None):
         return "# Page"
 
+    monkeypatch.setattr(service, "call_jina_reader", no_jina)
     monkeypatch.setattr(service, "call_tavily_extract", no_tavily)
     monkeypatch.setattr(service, "call_firecrawl_scrape", yes_firecrawl)
 
@@ -116,7 +120,7 @@ async def test_fetch_attempts_show_fallback(monkeypatch):
     assert result["ok"] is True
     assert result["provider"] == "firecrawl"
     assert result["fallback_used"] is True
-    assert [a["provider"] for a in result["provider_attempts"]] == ["tavily", "firecrawl"]
+    assert [a["provider"] for a in result["provider_attempts"]] == ["jina", "tavily", "firecrawl"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Adds Jina Reader as the first `web_fetch` provider for `smart-search fetch`, before Tavily and Firecrawl.

The default fetch chain is now:

```text
Jina Reader -> Tavily -> Firecrawl
```

Jina Reader basic mode works anonymously through `r.jina.ai`, so URL fetching can work out of the box without requiring a fetch provider API key.

## Design

This PR adds three new config keys:

- `JINA_API_KEY`
- `JINA_READER_API_URL`
- `JINA_RESPOND_WITH`

Default behavior:

- `JINA_READER_API_URL` defaults to `https://r.jina.ai`
- Basic Jina Reader fetch is used by default and does not require `JINA_API_KEY`
- `JINA_API_KEY` can be provided to raise Jina rate limits
- `JINA_RESPOND_WITH` is opt-in only

ReaderLM-v2 is intentionally not enabled by default. To use it, users must explicitly set:

```bash
smart-search config set JINA_RESPOND_WITH readerlm-v2
smart-search config set JINA_API_KEY <key>
```

This avoids making default `fetch` slower, more expensive, or more summary-like than normal page extraction.

## Why not enable ReaderLM-v2 by default?

I tested Jina Reader basic mode vs ReaderLM-v2 on several common complex pages:

- React docs
- Next.js docs
- arXiv HTML
- Wikipedia
- OpenAI blog

Observed behavior:

- Basic Jina Reader was fast and returned full page-like Markdown for React / Next.js / arXiv / Wikipedia.
- ReaderLM-v2 worked with an API key, but was much slower and returned substantially shorter model-processed output.
- ReaderLM-v2 did not help with the OpenAI blog URL because the target itself returned a 404 / anti-bot style page.

So ReaderLM-v2 is useful as an explicit high-quality conversion mode, but not a good default evidence-fetching mode.

## Documentation

Updated:

- `README.md`
- `README.zh-CN.md`
- public `skills/smart-search-cli`
- packaged `smart-search-cli` skill assets
- CLI contract reference

The docs now describe:

- Jina Reader as part of `web_fetch`
- the new fallback chain
- anonymous basic mode
- opt-in ReaderLM-v2 behavior

## Tests

Updated tests for the new fallback chain and minimum-profile semantics.

Validation run:

```bash
python -m pytest -q
```

Result:

```text
234 passed
```

Also manually verified:

```bash
smart-search fetch https://react.dev/reference/react/useState --format json
```

Result used `provider: jina` and returned page content successfully.
