### PR TITLE
feat: add research router and provider beta updates

### DIFF
--- a/.github/releases/v0.1.14-beta.2.md
+++ b/.github/releases/v0.1.14-beta.2.md
@@ -1,0 +1,21 @@
+# smart-search 0.1.14-beta.2
+
+Beta release for the research router, controlled Jina fetch support, and Zhipu MCP contract fixes.
+
+## Highlights
+
+- Added the live `smart-search research` executor with capability-first provider-advantage routing, same-capability fallback, evidence-only synthesis, degraded gap reporting, and safe research provider overrides.
+- Added Jina Reader as a controlled `web_fetch` provider. Jina remains fetch-only, requires `JINA_API_KEY` to satisfy the standard minimum profile, and supports isolated capability testing through `scripts/test-jina-capability.ps1`.
+- Added separate Zhipu Coding Plan Remote MCP routes for `web_search_prime`, `webReader`, and zread commands without mixing them into the existing `/paas/v4/web_search` Zhipu REST provider.
+- Aligned the live Zhipu MCP schema with observed tool contracts: `web_search_prime` uses `search_query`, and zread uses `repo_name`, `dir_path`, and `file_path`.
+- Clarified that normal Zhipu Web Search API keys do not imply GLM Coding Plan MCP entitlement. Missing or unauthorized MCP providers are skipped or fall through within the same capability, so the standard search/fetch fallback remains intact.
+
+## Validation
+
+- `.\.venv\Scripts\python.exe -m pytest -q`
+- `.\.venv\Scripts\python.exe -m smart_search.cli regression`
+- `.\.venv\Scripts\python.exe -m smart_search.cli smoke --mock --format json`
+- `.\.venv\Scripts\python.exe -m compileall -q src tests`
+- `npm test`
+- `npm pack --dry-run`
+- live doctor, live Jina capability check, and targeted Zhipu MCP auth/provider-error probes on Windows.

--- a/.trellis/spec/backend/provider-capability-contract.md
+++ b/.trellis/spec/backend/provider-capability-contract.md
@@ -99,9 +99,9 @@ Capabilities:
 | Capability | Provider order | Purpose |
 | --- | --- | --- |
 | `main_search` | `xai-responses`, `openai-compatible` | Broad answer generation and synthesis |
-| `web_search` | `zhipu`, `tavily`, `firecrawl` | General web-source reinforcement |
+| `web_search` | `zhipu`, `zhipu-mcp`, `tavily`, `firecrawl` | General web-source reinforcement |
 | `docs_search` | `context7`, `exa` by intent | Documentation, SDK, API, library, and framework lookup |
-| `web_fetch` | `tavily`, `firecrawl` | Known URL content extraction |
+| `web_fetch` | `tavily`, `jina`, `zhipu-mcp-reader`, `firecrawl` | Known URL content extraction |
 | `vertical_search` | `anysearch` | Experimental structured/vertical search evidence |
 | `synthesis` | currently successful `main_search` provider | Final answer synthesis |
 
@@ -156,6 +156,9 @@ Minimum profile:
   `docs_search`, and `web_fetch`.
 - `vertical_search` is optional and experimental. It must not satisfy or alter
   the `standard` minimum profile until a separate routing task accepts it.
+- Jina Reader satisfies `web_fetch` only when `JINA_API_KEY` is configured.
+  Anonymous `r.jina.ai` behavior is allowed only as explicit/experimental
+  degraded fetch behavior and must not make `standard` pass.
 - Missing required capability must fail closed before search execution.
 - `SMART_SEARCH_MINIMUM_PROFILE=off` is only for local experiments and tests.
 
@@ -190,6 +193,26 @@ Provider configuration:
   Search API. Do not describe or implement it as a GLM chat model choice,
   Chat Completions `tools=[web_search]`, Search Agent, or MCP Server unless a
   separate provider design task explicitly adds that route.
+- `ZHIPU_MCP_API_KEY` registers separate Zhipu Coding Plan Remote MCP
+  providers. It is not part of the `/paas/v4/web_search` REST provider.
+- `ZHIPU_MCP_SEARCH_API_URL` defaults to
+  `https://open.bigmodel.cn/api/mcp/web_search_prime/mcp` and calls
+  `webSearchPrime` for `web_search`.
+- `ZHIPU_MCP_READER_API_URL` defaults to
+  `https://open.bigmodel.cn/api/mcp/web_reader/mcp` and calls `webReader` for
+  `web_fetch`.
+- `ZHIPU_MCP_ZREAD_API_URL` defaults to
+  `https://open.bigmodel.cn/api/mcp/zread/mcp` and exposes explicit repo/docs
+  discovery commands for `search_doc`, `get_repo_structure`, and `read_file`.
+- Zhipu Coding Plan MCP must be implemented first as a narrow tested
+  MCP-over-HTTP provider layer. Avoid broad MCP abstractions until the
+  first search, reader, and zread tools are stable.
+- `JINA_API_KEY` registers Jina Reader as `web_fetch`.
+- `JINA_READER_API_URL` defaults to `https://r.jina.ai`.
+- `JINA_RESPOND_WITH` is optional. `JINA_RESPOND_WITH=readerlm-v2` requires
+  `JINA_API_KEY` and must fail before network when the key is absent.
+- Jina Reader is not a general `web_search` provider and must not be shown as
+  one in docs, setup, doctor, or capability status.
 - Legacy main-search keys are unsupported: `SMART_SEARCH_API_URL`,
   `SMART_SEARCH_API_KEY`, `SMART_SEARCH_API_MODE`, `SMART_SEARCH_MODEL`, and
   `SMART_SEARCH_XAI_TOOLS`. `config set` / `config unset` must reject them with
@@ -525,7 +548,12 @@ smart-search doctor --format json
 | Provider returns empty normalized result | Record `status="empty"` and try next same-capability provider when fallback is `auto` |
 | `--fallback off` | Try only the first matching provider in the capability chain |
 | Docs intent is false | Do not invoke Context7 or Exa as generic web-search fallback |
-| Fetch intent or known URL flow | Use `web_fetch` chain only: Tavily then Firecrawl |
+| Fetch intent or known URL flow | Use the shared `web_fetch` chain only: Tavily, Jina with key, Zhipu MCP Reader, then Firecrawl |
+| Jina Reader has no `JINA_API_KEY` | Do not register it as configured `web_fetch`; standard minimum profile remains missing unless another fetch provider is configured |
+| `JINA_RESPOND_WITH=readerlm-v2` without `JINA_API_KEY` | Return config error before network and do not count Jina toward `standard` |
+| Jina returns 401/403, 422, 429, timeout, network error, or challenge page such as `Title: Just a moment...` | Record a failed `web_fetch` provider attempt and continue same-capability fallback |
+| Zhipu Coding Plan MCP returns auth/rate/provider/timeout/network error | Record the error in `provider_attempts` when used through fallback and keep fallback same-capability |
+| Zhipu MCP auth is configured | Send `Authorization: Bearer <key>` and never log the token unmasked |
 | Strict validation has no sources | Return `error_type: "evidence_error"` instead of pretending success |
 | One live enhancement provider fails but same capability has fallback | Live smoke may mark the case `degraded`; critical paths still fail non-zero |
 | Interactive setup has guidance text | Write guidance to stderr and final rendered data to stdout |
@@ -673,7 +701,19 @@ When this contract changes, add or update tests that assert:
   strings, and list/tuple argv values produced by PowerShell wrapper flows;
 - Exa HTTP 400/422 responses surface as `parameter_error`, and docs-search
   fallback records them as provider errors rather than empty results;
-- Tavily fetch failure falls back to Firecrawl;
+- Tavily fetch failure falls back through Jina/Zhipu MCP Reader/Firecrawl as
+  configured;
+- Jina no-key does not satisfy `web_fetch`, Jina key does, and ReaderLM-v2
+  without key reports configuration error;
+- Jina and Remote MCP service wrappers await `_decode_provider_json(...)` and
+  return a decoded dict, never a coroutine object;
+- Jina empty/error/challenge output falls through to the next same-capability
+  fetch provider;
+- `fetch URL` and known-URL `search "https://..."` use the same fetch chain;
+- Zhipu Coding Plan Remote MCP mock calls cover `webSearchPrime`,
+  `webReader`, `search_doc`, `get_repo_structure`, and `read_file`;
+- Zhipu MCP auth header is sent, masked, and provider errors are recorded in
+  `provider_attempts` without cross-capability fallback;
 - strict validation returns insufficient evidence when sources are absent;
 - mock smoke covers minimum gate, fallback, routing, and secret masking.
 - `--format content` prints only `content` for `search`, `fetch`, and
@@ -825,12 +865,39 @@ Guide by capability, then show the final minimum-profile result:
 ```text
 [1/3 Required] main_search: xAI Responses or OpenAI-compatible
 [2/3 Required] docs_search: Context7 for docs/API; Exa for official domains, papers, and low-noise discovery
-[3/3 Required] web_fetch: Tavily or Firecrawl
+[3/3 Required] web_fetch: Tavily, Jina with key, Zhipu MCP Reader, or Firecrawl
 [Optional] web_search reinforcement: Zhipu / Tavily / Firecrawl
 ```
 
 This makes setup self-validating without relying on one developer's local
 environment.
+
+### Wrong
+
+Returning a provider JSON decoder coroutine from a public service wrapper:
+
+```python
+async def call_jina_reader(url: str) -> dict[str, Any]:
+    raw = await JinaReaderProvider(...).fetch_url(url)
+    return _decode_provider_json(raw, provider="jina")
+```
+
+This can pass type review while failing at runtime because CLI callers receive
+a coroutine instead of the normalized result dict.
+
+### Correct
+
+Await every async normalization boundary before returning from service wrappers:
+
+```python
+async def call_jina_reader(url: str) -> dict[str, Any]:
+    raw = await JinaReaderProvider(...).fetch_url(url)
+    return await _decode_provider_json(raw, provider="jina")
+```
+
+Add wrapper-level tests for each provider family (`Jina`, `AnySearch`, and
+`Zhipu MCP`) so future async helper changes cannot silently break the public
+CLI/service contract.
 
 ### Wrong
 

--- a/.trellis/spec/backend/provider-capability-contract.md
+++ b/.trellis/spec/backend/provider-capability-contract.md
@@ -241,6 +241,12 @@ Provider configuration:
 - `ZHIPU_MCP_ZREAD_API_URL` defaults to
   `https://open.bigmodel.cn/api/mcp/zread/mcp` and exposes explicit repo/docs
   discovery commands for `search_doc`, `get_repo_structure`, and `read_file`.
+- A normal Zhipu Web Search API key is not sufficient evidence of Coding Plan
+  entitlement. Do not assume `ZHIPU_API_KEY` authorizes `web_search_prime`,
+  `webReader`, or zread. If `ZHIPU_MCP_API_KEY` is missing or returns
+  auth/provider errors, MCP providers must be skipped or fall through within
+  the same capability; zread remains explicit and does not affect the
+  `standard` minimum profile.
 - Zhipu Coding Plan MCP must be implemented first as a narrow tested
   MCP-over-HTTP provider layer. Avoid broad MCP abstractions until the
   first search, reader, and zread tools are stable.

--- a/.trellis/spec/backend/provider-capability-contract.md
+++ b/.trellis/spec/backend/provider-capability-contract.md
@@ -234,7 +234,7 @@ Provider configuration:
   providers. It is not part of the `/paas/v4/web_search` REST provider.
 - `ZHIPU_MCP_SEARCH_API_URL` defaults to
   `https://open.bigmodel.cn/api/mcp/web_search_prime/mcp` and calls
-  `webSearchPrime` for `web_search`.
+  `web_search_prime` for `web_search`.
 - `ZHIPU_MCP_READER_API_URL` defaults to
   `https://open.bigmodel.cn/api/mcp/web_reader/mcp` and calls `webReader` for
   `web_fetch`.
@@ -761,7 +761,7 @@ When this contract changes, add or update tests that assert:
 - Jina empty/error/challenge output falls through to the next same-capability
   fetch provider;
 - `fetch URL` and known-URL `search "https://..."` use the same fetch chain;
-- Zhipu Coding Plan Remote MCP mock calls cover `webSearchPrime`,
+- Zhipu Coding Plan Remote MCP mock calls cover `web_search_prime`,
   `webReader`, `search_doc`, `get_repo_structure`, and `read_file`;
 - Zhipu MCP auth header is sent, masked, and provider errors are recorded in
   `provider_attempts` without cross-capability fallback;

--- a/.trellis/spec/backend/provider-capability-contract.md
+++ b/.trellis/spec/backend/provider-capability-contract.md
@@ -29,6 +29,12 @@ smart-search search QUERY
   [--providers auto|CSV]
   [--stream | --no-stream]
   [--format json|markdown|content]
+smart-search research QUERY
+  [--budget quick|standard|deep]
+  [--evidence-dir PATH]
+  [--fallback auto|off]
+  [--format json|markdown|content]
+  [--output PATH]
 
 smart-search doctor --format json|markdown|content
 smart-search diagnose openai-compatible
@@ -81,6 +87,7 @@ get_capability_status() -> dict[str, Any]
 validate_minimum_profile() -> dict[str, Any]
 search(query, platform="", model="", extra_sources=0,
        validation="", fallback="", providers="auto") -> dict[str, Any]
+research(query, budget="deep", evidence_dir="", fallback="auto") -> dict[str, Any]
 doctor() -> dict[str, Any]
 diagnose_openai_compatible(timeout_seconds=30.0) -> dict[str, Any]
 smoke(mode="mock") -> dict[str, Any]
@@ -113,7 +120,15 @@ Deep Research planner orchestration:
 - `smart-search deep` is a planner, not an executor. It must not call live
   providers, run `doctor`, fetch pages, or change configuration by default.
   Live research happens only when the AI agent or user executes the planned
-  `steps[].command` values.
+  `steps[].command` values, or when the user calls `smart-search research`.
+- `smart-search research QUERY [--budget quick|standard|deep] [--evidence-dir
+  PATH] [--fallback auto|off]` is the live Deep Research executor. It performs
+  plan -> source discovery -> fetch/read -> gap check -> evidence-only
+  synthesis.
+- `research --fallback auto` is the default and permits same-capability
+  fallback inside selected routes. `research --fallback off` tries only the
+  first selected provider for each capability and is intended for debugging and
+  deterministic provider checks.
 - `smart-search search` remains the fast live-search entrypoint and must not be
   silently upgraded into Deep Research.
 - Deep Research planning is capability-based. Do not require fixed topic recipe
@@ -148,6 +163,28 @@ Deep Research planner orchestration:
   questions, `fetch` plus `exa-similar` for known URLs, and `exa-search` only
   for official domains, papers, product pages, trusted sites, or explicit
   low-noise discovery needs.
+- Research provider selection is capability-first and provider-advantage
+  second. Future providers must register a profile before joining `research`.
+  Profiles declare supported capability, strengths, exclusions, fallback group,
+  minimum-profile role, quality filters, route reasons, and experimental status.
+- Safe research overrides are
+  `SMART_SEARCH_RESEARCH_PREFERRED_PROVIDERS` and
+  `SMART_SEARCH_RESEARCH_DISABLED_PROVIDERS`. They may reorder or disable
+  providers only inside capabilities the provider already supports. Unknown
+  providers are reported in routing metadata and ignored; overrides must never
+  move a provider across capability boundaries.
+- Baseline `research` provider advantages:
+  Context7 for library/API/framework docs; Exa for official domains, papers,
+  product/company pages, date/domain-filtered low-noise discovery, and adjacent
+  sources; Zhipu REST for Chinese/domestic/current/policy/announcement
+  searches; Zhipu MCP only as the separate Coding Plan quota route; Tavily for
+  broad discovery and site maps; Jina for known public URL/PDF/arXiv clean
+  extraction; Firecrawl for JS-heavy/dynamic/browser-like/OCR/PDF/structured
+  extraction fallback; AnySearch only when vertical intent is clear.
+- Research final synthesis receives only fetched/read evidence and structured
+  source metadata. It must not call web providers again and must not cite
+  unfetched discovery candidates as proof. If evidence cannot close, return a
+  degraded result with explicit gaps instead of unsupported claims.
 
 Minimum profile:
 
@@ -343,12 +380,15 @@ Output contracts:
   metadata, and full long error/message detail instead of falling back to raw
   JSON.
 - `--format content` prints only the `content` field for content-bearing
-  commands (`search`, `fetch`, `context7-docs`). Commands without a `content`
-  field, including `doctor`, `smoke`, `config`, and `model`, must print a
-  compact non-empty text summary rather than empty stdout.
+  commands (`search`, `fetch`, `context7-docs`, `research`). Commands without a
+  `content` field, including `doctor`, `smoke`, `config`, and `model`, must
+  print a compact non-empty text summary rather than empty stdout.
 - Include observability fields: `routing_decision`, `providers_used`,
   `provider_attempts`, `fallback_used`, `validation_level`,
   `minimum_profile_ok`, and `capability_status`.
+- `research` JSON must include `final_answer`, `content`, `citations`,
+  `evidence_items`, `gap_check`, `provider_attempts`, `fallback_used`,
+  `degraded`, `route_policy_version`, and `evidence_dir`.
 - `search` must expose the effective OpenAI-compatible stream decision in
   `routing_decision.openai_compatible_stream` when that provider is attempted.
 - AnySearch command output must include `provider="anysearch"`, `tool`,
@@ -547,6 +587,7 @@ smart-search doctor --format json
 | Provider HTTP/network/timeout/schema error | Record `provider_attempts[].status="error"` and try next same-capability provider when fallback is `auto` |
 | Provider returns empty normalized result | Record `status="empty"` and try next same-capability provider when fallback is `auto` |
 | `--fallback off` | Try only the first matching provider in the capability chain |
+| `research --fallback off` | Try only the first selected provider inside each capability route and report gaps rather than continuing through same-capability fallback |
 | Docs intent is false | Do not invoke Context7 or Exa as generic web-search fallback |
 | Fetch intent or known URL flow | Use the shared `web_fetch` chain only: Tavily, Jina with key, Zhipu MCP Reader, then Firecrawl |
 | Jina Reader has no `JINA_API_KEY` | Do not register it as configured `web_fetch`; standard minimum profile remains missing unless another fetch provider is configured |
@@ -575,6 +616,9 @@ smart-search doctor --format json
 | Packaged npm/mise install runs `smart-search regression` without `tests/` | Run built-in mock smoke fallback and report that repository tests are absent |
 | Skill contract changes | Keep `skills/smart-search-cli/**` and `src/smart_search/assets/skills/smart-search-cli/**` synchronized |
 | Deep Research skill contract changes | Assert `intent_signals`, `capability_plan`, `gap_check`, expanded tool allowlist, non-recipe schema, and README coverage |
+| Research executor has discovery snippets but no fetched evidence | Return degraded or failed gap report and do not cite discovery candidates |
+| Research provider advantage route changes | Add mock routing tests for docs/API, Chinese/current/policy, known URL/PDF/arXiv, JS-heavy/dynamic fetch, and vertical AnySearch intent |
+| Research fallback route changes | Assert fallback never crosses capability, provider failures and quality errors are recorded, and `--fallback off` disables same-capability fallback |
 | Already published npm version needs changed packaged assets | Do not assume retagging updates npm; cut a new patch version for installable artifacts |
 | Need a test npm publish without moving `latest` | Push a commit to `main` and verify the Actions run publishes `<base>-beta.N` with dist-tag `next` |
 
@@ -669,6 +713,13 @@ When this contract changes, add or update tests that assert:
 - capability fallback order is fixed and same-capability only;
 - provider error and empty result both trigger fallback;
 - `--fallback off` stops after the first provider;
+- provider profiles route `research` by capability first and provider advantage
+  second;
+- `research` executes staged plan, discovery, fetch/read, gap check, and
+  evidence-only synthesis with mocked providers;
+- `research` does not cite unfetched discovery candidates and returns degraded
+  gaps when evidence cannot close;
+- `research --fallback off` disables same-capability fallback;
 - provider filters apply to main-search ids and aliases;
 - xAI Responses and OpenAI-compatible use separate explicit config families;
 - `XAI_API_KEY` alone does not fabricate an OpenAI-compatible fallback;

--- a/.trellis/workspace/dxt98/index.md
+++ b/.trellis/workspace/dxt98/index.md
@@ -8,8 +8,8 @@
 
 <!-- @@@auto:current-status -->
 - **Active File**: `journal-1.md`
-- **Total Sessions**: 16
-- **Last Active**: 2026-05-30
+- **Total Sessions**: 17
+- **Last Active**: 2026-06-06
 <!-- @@@/auto:current-status -->
 
 ---
@@ -19,7 +19,7 @@
 <!-- @@@auto:active-documents -->
 | File | Lines | Status |
 |------|-------|--------|
-| `journal-1.md` | ~607 | Active |
+| `journal-1.md` | ~650 | Active |
 <!-- @@@/auto:active-documents -->
 
 ---
@@ -29,6 +29,7 @@
 <!-- @@@auto:session-history -->
 | # | Date | Title | Commits | Branch |
 |---|------|-------|---------|--------|
+| 17 | 2026-06-06 | Jina and Zhipu MCP provider beta | `b19d00c` | `codex/update-anysearch-readme-links` |
 | 16 | 2026-05-30 | OpenAI-compatible diagnose command | `a62efcc` | `main` |
 | 15 | 2026-05-26 | Skill sync command and search routing rebalance | `33be99b` | `main` |
 | 14 | 2026-05-15 | Global smart-search skill setup and Tavily doctor timeout | `015439b` | `main` |

--- a/.trellis/workspace/dxt98/index.md
+++ b/.trellis/workspace/dxt98/index.md
@@ -8,7 +8,7 @@
 
 <!-- @@@auto:current-status -->
 - **Active File**: `journal-1.md`
-- **Total Sessions**: 17
+- **Total Sessions**: 18
 - **Last Active**: 2026-06-06
 <!-- @@@/auto:current-status -->
 
@@ -19,7 +19,7 @@
 <!-- @@@auto:active-documents -->
 | File | Lines | Status |
 |------|-------|--------|
-| `journal-1.md` | ~650 | Active |
+| `journal-1.md` | ~692 | Active |
 <!-- @@@/auto:active-documents -->
 
 ---
@@ -29,6 +29,7 @@
 <!-- @@@auto:session-history -->
 | # | Date | Title | Commits | Branch |
 |---|------|-------|---------|--------|
+| 18 | 2026-06-06 | Research router and fallback | `6798283` | `codex/update-anysearch-readme-links` |
 | 17 | 2026-06-06 | Jina and Zhipu MCP provider beta | `b19d00c` | `codex/update-anysearch-readme-links` |
 | 16 | 2026-05-30 | OpenAI-compatible diagnose command | `a62efcc` | `main` |
 | 15 | 2026-05-26 | Skill sync command and search routing rebalance | `33be99b` | `main` |

--- a/.trellis/workspace/dxt98/index.md
+++ b/.trellis/workspace/dxt98/index.md
@@ -8,7 +8,7 @@
 
 <!-- @@@auto:current-status -->
 - **Active File**: `journal-1.md`
-- **Total Sessions**: 18
+- **Total Sessions**: 19
 - **Last Active**: 2026-06-06
 <!-- @@@/auto:current-status -->
 
@@ -19,7 +19,7 @@
 <!-- @@@auto:active-documents -->
 | File | Lines | Status |
 |------|-------|--------|
-| `journal-1.md` | ~692 | Active |
+| `journal-1.md` | ~730 | Active |
 <!-- @@@/auto:active-documents -->
 
 ---
@@ -29,6 +29,7 @@
 <!-- @@@auto:session-history -->
 | # | Date | Title | Commits | Branch |
 |---|------|-------|---------|--------|
+| 19 | 2026-06-06 | Research router Jina and Zhipu MCP beta closeout | `b19d00c`, `539cb0e`, `6798283`, `205c7a6`, `d01814c`, `c775043` | `codex/update-anysearch-readme-links` |
 | 18 | 2026-06-06 | Research router and fallback | `6798283` | `codex/update-anysearch-readme-links` |
 | 17 | 2026-06-06 | Jina and Zhipu MCP provider beta | `b19d00c` | `codex/update-anysearch-readme-links` |
 | 16 | 2026-05-30 | OpenAI-compatible diagnose command | `a62efcc` | `main` |

--- a/.trellis/workspace/dxt98/journal-1.md
+++ b/.trellis/workspace/dxt98/journal-1.md
@@ -184,7 +184,10 @@ Added direct content output, balanced realtime sports web reinforcement, package
 
 ### Main Changes
 
-(Add details)
+- Implemented Jina Reader as controlled `web_fetch` only: key-required for the standard minimum profile, ReaderLM-v2 fail-closed without key, challenge/empty/error filtering, and same-capability fallback.
+- Implemented separate Zhipu Coding Plan Remote MCP provider paths for `webSearchPrime`, `webReader`, and zread repo/docs discovery tools without mixing them into the existing Zhipu REST Web Search provider.
+- Updated setup/config, doctor/status, public and packaged skill docs, README files, provider-capability spec, and unit/regression tests.
+- Captured the async wrapper gotcha where provider JSON decoders must be awaited before returning from service-level wrappers.
 
 ### Git Commits
 
@@ -195,7 +198,13 @@ Added direct content output, balanced realtime sports web reinforcement, package
 
 ### Testing
 
-- [OK] (Add test results)
+- [OK] `.venv\Scripts\python.exe -m pytest tests -q` -> 257 passed.
+- [OK] `.venv\Scripts\python.exe -m smart_search.cli regression` -> 195 passed.
+- [OK] `.venv\Scripts\python.exe -m smart_search.cli smoke --mock --format json` -> `ok: true`.
+- [OK] `python -m compileall -q src tests`.
+- [OK] `git diff --check` with line-ending warnings only.
+- [OK] `npm pack --dry-run` included Jina/Zhipu MCP provider files and bundled skill assets.
+- [OK] Secret scan found no real Jina key in the repository.
 
 ### Status
 
@@ -603,6 +612,39 @@ Added a beginner-facing diagnose openai-compatible command, enhanced search time
 | Hash | Message |
 |------|---------|
 | `a62efcc` | (see git log) |
+
+### Testing
+
+- [OK] (Add test results)
+
+### Status
+
+[OK] **Completed**
+
+### Next Steps
+
+- None - task complete
+
+
+## Session 17: Jina and Zhipu MCP provider beta
+
+**Date**: 2026-06-06
+**Task**: Jina and Zhipu MCP provider beta
+**Branch**: `codex/update-anysearch-readme-links`
+
+### Summary
+
+Added controlled Jina web_fetch support and separate Zhipu Coding Plan Remote MCP providers; updated setup/config/docs/skills/spec/tests; source validation passed with pytest, regression, mock smoke, compileall, diff check, secret scan, and npm dry-run.
+
+### Main Changes
+
+(Add details)
+
+### Git Commits
+
+| Hash | Message |
+|------|---------|
+| `b19d00c` | (see git log) |
 
 ### Testing
 

--- a/.trellis/workspace/dxt98/journal-1.md
+++ b/.trellis/workspace/dxt98/journal-1.md
@@ -657,3 +657,36 @@ Added controlled Jina web_fetch support and separate Zhipu Coding Plan Remote MC
 ### Next Steps
 
 - None - task complete
+
+
+## Session 18: Research router and fallback
+
+**Date**: 2026-06-06
+**Task**: Research router and fallback
+**Branch**: `codex/update-anysearch-readme-links`
+
+### Summary
+
+Added the live research executor with capability-first provider-advantage routing, same-capability fallback, safe research provider overrides, evidence-only synthesis, synchronized docs/skills/provider contract, and completed full unit, regression, mock smoke, live doctor, live research, and live smoke verification.
+
+### Main Changes
+
+(Add details)
+
+### Git Commits
+
+| Hash | Message |
+|------|---------|
+| `6798283` | (see git log) |
+
+### Testing
+
+- [OK] (Add test results)
+
+### Status
+
+[OK] **Completed**
+
+### Next Steps
+
+- None - task complete

--- a/.trellis/workspace/dxt98/journal-1.md
+++ b/.trellis/workspace/dxt98/journal-1.md
@@ -690,3 +690,41 @@ Added the live research executor with capability-first provider-advantage routin
 ### Next Steps
 
 - None - task complete
+
+
+## Session 19: Research router Jina and Zhipu MCP beta closeout
+
+**Date**: 2026-06-06
+**Task**: Research router Jina and Zhipu MCP beta closeout
+**Branch**: `codex/update-anysearch-readme-links`
+
+### Summary
+
+Closed out the beta provider work: Jina fetch-only support, Zhipu Coding Plan MCP schema/error handling, live research router and same-capability fallback, provider-boundary documentation, Jina capability probe script, and release notes for 0.1.14-beta.2.
+
+### Main Changes
+
+(Add details)
+
+### Git Commits
+
+| Hash | Message |
+|------|---------|
+| `b19d00c` | (see git log) |
+| `539cb0e` | (see git log) |
+| `6798283` | (see git log) |
+| `205c7a6` | (see git log) |
+| `d01814c` | (see git log) |
+| `c775043` | (see git log) |
+
+### Testing
+
+- [OK] (Add test results)
+
+### Status
+
+[OK] **Completed**
+
+### Next Steps
+
+- None - task complete

--- a/README.md
+++ b/README.md
@@ -116,8 +116,8 @@ provider keys or create Trellis/hooks/agents/commands.
 | --- | --- | --- | --- |
 | `main_search` | `search` | xAI Responses, OpenAI-compatible Chat Completions | Broad answer generation and synthesis |
 | `docs_search` | `context7-library`, `context7-docs`, `exa-search` | Context7, Exa | Official docs, SDKs, APIs, framework/library evidence |
-| `web_search` | `zhipu-search`, intent-routed reinforcement inside `search` | Zhipu, Tavily, Firecrawl | Chinese, domestic, current, domain-filtered, or supplementary web discovery |
-| `web_fetch` | `fetch` | Tavily, Firecrawl | Exact URL content extraction for evidence |
+| `web_search` | `zhipu-search`, `zhipu-mcp-search`, intent-routed reinforcement inside `search` | Zhipu Web Search API, Zhipu Coding Plan MCP, Tavily, Firecrawl | Chinese, domestic, current, domain-filtered, or supplementary web discovery |
+| `web_fetch` | `fetch`, `zhipu-mcp-reader` | Tavily, Jina Reader, Zhipu Coding Plan MCP Reader, Firecrawl | Exact URL content extraction for evidence |
 | `vertical_search` | `anysearch-domains`, `anysearch-search`, `anysearch-extract`, `anysearch-batch` | AnySearch (experimental) | Acceptance testing for structured vertical domains such as CVE, finance, legal, academic, and code/docs |
 | `site_map` | `map` | Tavily | Site/documentation structure discovery |
 | `deep_planner` | `deep` / `dr` | Local planner only | Offline plan generation; no provider call by default |
@@ -128,16 +128,18 @@ Fallback is same-capability only:
 | --- | --- |
 | `main_search` | xAI Responses -> OpenAI-compatible |
 | `docs_search` | Context7 for library/API/docs intent; Exa for official domains, papers, product pages, and trusted-site discovery |
-| `web_search` | Zhipu -> Tavily -> Firecrawl |
-| `web_fetch` | Tavily -> Firecrawl |
+| `web_search` | Zhipu Web Search API -> Zhipu Coding Plan MCP `webSearchPrime` -> Tavily -> Firecrawl |
+| `web_fetch` | Tavily -> Jina Reader with `JINA_API_KEY` -> Zhipu Coding Plan MCP `webReader` -> Firecrawl |
 
 AnySearch is intentionally not part of the `web_search` fallback chain and is not required by the `standard` minimum profile. Use its explicit commands for acceptance and boundary testing before promoting any vertical domain into a future route.
+
+Jina Reader is a `web_fetch` provider only. `JINA_API_KEY` is required before Jina satisfies `SMART_SEARCH_MINIMUM_PROFILE=standard`; anonymous `r.jina.ai` behavior is treated as explicit/experimental fetch behavior and must not weaken fail-closed setup checks.
 
 The CLI exposes observability fields such as `routing_decision`, `provider_attempts`, `providers_used`, `fallback_used`, `primary_sources`, `extra_sources`, and `source_warning`.
 
 `extra_sources` are discovery candidates. For high-risk claims, news, policy, finance, health, selection decisions, and serious reviews, fetch key pages first and cite fetched text rather than treating a broad search answer as proof.
 
-Routing rule of thumb: start with `search` for broad discovery and synthesis; use Zhipu for Chinese, domestic, policy, announcements, and current-news searches; use Context7 first for library/API/framework docs; use Exa for official domains, papers, product pages, trusted sites, and low-noise discovery; use Tavily/Firecrawl through `search --extra-sources` for horizontal candidates and through `fetch` for page evidence; use AnySearch only when you explicitly need experimental vertical-domain search.
+Routing rule of thumb: start with `search` for broad discovery and synthesis; use Zhipu Web Search API for Chinese, domestic, policy, announcements, and current-news searches; use Zhipu Coding Plan MCP only when you explicitly want the Coding Plan quota route; use Context7 first for library/API/framework docs; use Exa for official domains, papers, product pages, trusted sites, and low-noise discovery; use Tavily/Firecrawl through `search --extra-sources` for horizontal candidates and through `fetch` for page evidence; use Jina for known-URL extraction; use AnySearch only when you explicitly need experimental vertical-domain search.
 
 ## Deep Research
 
@@ -195,7 +197,9 @@ Use `smart-search setup` for normal configuration. Environment variables remain 
 | Exa | Low-noise official docs, API, paper, product, trusted-page discovery | `EXA_API_KEY` | [Exa docs](https://docs.exa.ai/) | [Exa API keys](https://dashboard.exa.ai/api-keys) |
 | Context7 | SDK, library, framework, and API documentation fallback | `CONTEXT7_API_KEY`, `CONTEXT7_BASE_URL` | [Context7 docs](https://context7.com/docs) | [Context7](https://context7.com/) |
 | Zhipu Web Search API | Chinese, domestic, current, or domain-filtered web discovery | `ZHIPU_API_KEY`, `ZHIPU_API_URL`, `ZHIPU_SEARCH_ENGINE` | [Zhipu web search docs](https://docs.bigmodel.cn/cn/guide/tools/web-search) | [Zhipu API keys](https://open.bigmodel.cn/usercenter/apikeys) |
+| Zhipu Coding Plan Remote MCP | Coding Plan quota web search, page reading, and open-source repo discovery | `ZHIPU_MCP_API_KEY`, `ZHIPU_MCP_SEARCH_API_URL`, `ZHIPU_MCP_READER_API_URL`, `ZHIPU_MCP_ZREAD_API_URL` | [search MCP](https://docs.bigmodel.cn/cn/coding-plan/mcp/search-mcp-server), [reader MCP](https://docs.bigmodel.cn/cn/coding-plan/mcp/reader-mcp-server), [zread MCP](https://docs.bigmodel.cn/cn/coding-plan/mcp/zread-mcp-server) | [Zhipu API keys](https://open.bigmodel.cn/usercenter/apikeys) |
 | Tavily | Extra web sources, URL fetch, and site map | `TAVILY_API_URL`, `TAVILY_API_KEY` | [Tavily docs](https://docs.tavily.com/) | [Tavily app](https://app.tavily.com/home) |
+| Jina Reader | Known URL page extraction for `web_fetch`; key required for standard minimum profile | `JINA_API_KEY`, `JINA_READER_API_URL`, `JINA_RESPOND_WITH`, `JINA_TIMEOUT_SECONDS` | [Jina Reader](https://jina.ai/reader/) | [Jina AI](https://jina.ai/) |
 | Firecrawl | Fetch fallback and supplementary web sources | `FIRECRAWL_API_URL`, `FIRECRAWL_API_KEY` | [Firecrawl docs](https://docs.firecrawl.dev/) | [Firecrawl API keys](https://www.firecrawl.dev/app/api-keys) |
 | AnySearch | Experimental vertical search acceptance surface; not a default fallback | `ANYSEARCH_API_URL`, `ANYSEARCH_API_KEY`, `ANYSEARCH_TIMEOUT_SECONDS` | [AnySearch docs](https://www.anysearch.com/docs) | [AnySearch API keys](https://www.anysearch.com/console/api-keys) |
 
@@ -205,7 +209,9 @@ Important boundaries:
 - `OPENAI_COMPATIBLE_STREAM=true` or `smart-search search --stream` sets `stream=true` only for OpenAI-compatible `search` and provider-side `fetch` calls. It is a relay compatibility switch for long requests and does not change xAI Responses behavior, URL description, or source ranking.
 - Legacy `SMART_SEARCH_API_URL`, `SMART_SEARCH_API_KEY`, `SMART_SEARCH_API_MODE`, `SMART_SEARCH_MODEL`, and `SMART_SEARCH_XAI_TOOLS` are not supported config keys. Use `XAI_*` or `OPENAI_COMPATIBLE_*` explicitly.
 - Do not force xAI `web_search` / `x_search` tools or legacy `search_parameters` into the OpenAI-compatible Chat Completions route.
-- Zhipu support is the Web Search API route, not Zhipu Chat Completions `tools=[web_search]`, not Search Agent, and not the MCP Server.
+- `zhipu-search` support is the Web Search API route, not Zhipu Chat Completions `tools=[web_search]`, not Search Agent, and not the MCP Server.
+- Zhipu Coding Plan support is a separate Remote MCP route. `webSearchPrime` maps to `web_search`, `webReader` maps to `web_fetch`, and zread tools map to explicit repo/docs discovery commands. It is not mixed into the existing `/paas/v4/web_search` Zhipu REST provider.
+- Jina Reader is not a general search provider. `JINA_API_KEY` is required for Jina to count toward `standard`; `JINA_RESPOND_WITH=readerlm-v2` also requires `JINA_API_KEY`.
 - `ZHIPU_SEARCH_ENGINE` defaults to `search_std`. Supported official values include `search_std`, `search_pro`, `search_pro_sogou`, and `search_pro_quark`; custom values remain allowed for future services.
 - `TAVILY_API_URL` affects Tavily only. It does not proxy Zhipu. For Tavily Hikari / pooled endpoints, use `https://<host>/api/tavily`; setup normalizes root-host or `/mcp` inputs to that REST base.
 - `FIRECRAWL_API_URL` defaults to `https://api.firecrawl.dev/v2`.
@@ -229,6 +235,8 @@ smart-search setup --non-interactive `
   --zhipu-key "your-zhipu-key" `
   --zhipu-api-url "https://open.bigmodel.cn/api" `
   --zhipu-search-engine "search_pro_sogou" `
+  --zhipu-mcp-key "your-zhipu-coding-plan-key" `
+  --jina-key "your-jina-key" `
   --tavily-api-url "https://api.tavily.com" `
   --tavily-key "your-tavily-key" `
   --firecrawl-api-url "https://api.firecrawl.dev/v2" `
@@ -239,7 +247,7 @@ Minimum profile defaults to `standard`, requiring at least:
 
 - one `main_search` provider: xAI Responses or OpenAI-compatible;
 - one `docs_search` provider: Exa or Context7;
-- one `web_fetch` provider: Tavily or Firecrawl.
+- one `web_fetch` provider: Tavily, Jina with `JINA_API_KEY`, Zhipu Coding Plan MCP Reader, or Firecrawl.
 
 Missing required capabilities fail closed with a configuration error. Use `SMART_SEARCH_MINIMUM_PROFILE=off` only for local experiments.
 
@@ -279,6 +287,11 @@ Provider timeouts:
 | `exa-search` | `exa`, `x` | Exa source discovery |
 | `exa-similar` | `xs` | Similar pages from one URL |
 | `zhipu-search` | `z`, `zp` | Zhipu Web Search API |
+| `zhipu-mcp-search` | `zmcp-search` | Zhipu Coding Plan MCP `webSearchPrime` |
+| `zhipu-mcp-reader` | `zmcp-reader` | Zhipu Coding Plan MCP `webReader` |
+| `zhipu-mcp-search-doc` | `zmcp-doc` | Search open-source repository docs through zread MCP |
+| `zhipu-mcp-repo-structure` | `zmcp-tree` | Read repository structure through zread MCP |
+| `zhipu-mcp-read-file` | `zmcp-file` | Read one repository file through zread MCP |
 | `anysearch-domains` | `as-domains` | Experimental AnySearch domain discovery |
 | `anysearch-search` | `as-search`, `as` | Experimental AnySearch vertical/general search |
 | `anysearch-extract` | `as-extract` | Experimental AnySearch URL extraction |
@@ -304,6 +317,9 @@ smart-search exa-search "OpenAI Responses API documentation" --include-domains p
 smart-search context7-library "react" "hooks" --format json
 smart-search context7-docs "/facebook/react" "useEffect cleanup" --format json
 smart-search zhipu-search "today China AI news" --search-engine search_pro_sogou --count 5 --format json
+smart-search zhipu-mcp-search "today China AI news" --count 5 --format json
+smart-search zhipu-mcp-reader "https://example.com/source" --format json
+smart-search zhipu-mcp-search-doc "owner/repo" "install" --format json
 smart-search anysearch-search "CVE-2024-3094" --domain security.cve --max-results 3 --format json
 smart-search anysearch-extract "https://example.com/source" --format json
 smart-search exa-similar "https://example.com/source" --num-results 5 --format json

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ Use `smart-search setup` for normal configuration. Environment variables remain 
 | Zhipu Web Search API | Chinese, domestic, current, or domain-filtered web discovery | `ZHIPU_API_KEY`, `ZHIPU_API_URL`, `ZHIPU_SEARCH_ENGINE` | [Zhipu web search docs](https://docs.bigmodel.cn/cn/guide/tools/web-search) | [Zhipu API keys](https://open.bigmodel.cn/usercenter/apikeys) |
 | Tavily | Extra web sources, URL fetch, and site map | `TAVILY_API_URL`, `TAVILY_API_KEY` | [Tavily docs](https://docs.tavily.com/) | [Tavily app](https://app.tavily.com/home) |
 | Firecrawl | Fetch fallback and supplementary web sources | `FIRECRAWL_API_URL`, `FIRECRAWL_API_KEY` | [Firecrawl docs](https://docs.firecrawl.dev/) | [Firecrawl API keys](https://www.firecrawl.dev/app/api-keys) |
-| AnySearch | Experimental vertical search acceptance surface; not a default fallback | `ANYSEARCH_API_URL`, `ANYSEARCH_API_KEY`, `ANYSEARCH_TIMEOUT_SECONDS` | Provider documentation | AnySearch dashboard / provider console |
+| AnySearch | Experimental vertical search acceptance surface; not a default fallback | `ANYSEARCH_API_URL`, `ANYSEARCH_API_KEY`, `ANYSEARCH_TIMEOUT_SECONDS` | [AnySearch docs](https://www.anysearch.com/docs) | [AnySearch API keys](https://www.anysearch.com/console/api-keys) |
 
 Important boundaries:
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [简体中文](README.zh-CN.md) | English
 
-CLI-first, skill-driven web research for AI agents and terminal users. `smart-search` gives AI tools one reproducible command layer for live search, source discovery, page fetching, site mapping, provider diagnostics, and offline Deep Research planning.
+CLI-first, skill-driven web research for AI agents and terminal users. `smart-search` gives AI tools one reproducible command layer for live search, source discovery, page fetching, site mapping, provider diagnostics, offline Deep Research planning, and live Deep Research execution.
 
 <p>
   <a href="https://www.npmjs.com/package/@konbakuyomu/smart-search">
@@ -20,6 +20,7 @@ CLI-first, skill-driven web research for AI agents and terminal users. `smart-se
 smart-search search "latest OpenAI Responses API changes" --format json
 smart-search fetch "https://example.com/article" --format markdown
 smart-search deep "Compare Responses API web_search with Chat Completions search" --format json
+smart-search research "Compare Responses API web_search with Chat Completions search" --format markdown
 ```
 
 The current architecture has two layers:
@@ -29,7 +30,7 @@ The current architecture has two layers:
 | CLI executor | Runs deterministic commands, provider routing, fallback, JSON/Markdown output, local config, smoke/regression checks |
 | Skill / AI orchestration | Infers user intent, chooses normal search vs Deep Research, executes planned CLI steps, writes final source-backed answers |
 
-Default `smart-search search` stays fast and live. `smart-search deep` is the explicit offline Deep Research planner. It does not call providers, run `doctor`, or fetch pages by default; it emits a `research_plan` that an AI agent or user can execute step by step.
+Default `smart-search search` stays fast and live. `smart-search deep` is the explicit offline Deep Research planner. It does not call providers, run `doctor`, or fetch pages by default; it emits a `research_plan` that an AI agent or user can execute step by step. `smart-search research` is the live Deep Research executor: it uses the same planner shape, then runs discovery, fetch/read, gap check, and evidence-only synthesis.
 
 ## Install
 
@@ -89,7 +90,13 @@ smart-search fetch "https://example.com/source" --format markdown --output evide
 smart-search deep "Deep research recent Bitcoin market movement" --budget standard --format json
 ```
 
-6. Install the skill for AI tools when setup prompts you, or explicitly:
+6. Run live Deep Research when you want the CLI to execute the staged workflow:
+
+```powershell
+smart-search research "Deep research recent Bitcoin market movement" --budget deep --format markdown
+```
+
+7. Install the skill for AI tools when setup prompts you, or explicitly:
 
 ```powershell
 smart-search setup --non-interactive --install-skills codex,claude,cursor,hermes
@@ -99,7 +106,7 @@ Skill installation writes the bundled `smart-search-cli` skill into user-level t
 `~/.codex/skills`, `~/.claude/skills`, `~/.cursor/skills`, and `~/.hermes/skills`. It does not initialize
 Trellis, hooks, agents, or commands. `--skills-root PATH` is only an advanced override for portable or test installs.
 
-7. After upgrading the CLI, refresh the installed global skill:
+8. After upgrading the CLI, refresh the installed global skill:
 
 ```powershell
 smart-search skills status --targets codex --format json
@@ -121,6 +128,7 @@ provider keys or create Trellis/hooks/agents/commands.
 | `vertical_search` | `anysearch-domains`, `anysearch-search`, `anysearch-extract`, `anysearch-batch` | AnySearch (experimental) | Acceptance testing for structured vertical domains such as CVE, finance, legal, academic, and code/docs |
 | `site_map` | `map` | Tavily | Site/documentation structure discovery |
 | `deep_planner` | `deep` / `dr` | Local planner only | Offline plan generation; no provider call by default |
+| `research_executor` | `research` / `rs` | Registered providers by capability | Live staged research: plan, discover, fetch/read, gap check, evidence-only synthesis |
 
 Fallback is same-capability only:
 
@@ -139,7 +147,7 @@ The CLI exposes observability fields such as `routing_decision`, `provider_attem
 
 `extra_sources` are discovery candidates. For high-risk claims, news, policy, finance, health, selection decisions, and serious reviews, fetch key pages first and cite fetched text rather than treating a broad search answer as proof.
 
-Routing rule of thumb: start with `search` for broad discovery and synthesis; use Zhipu Web Search API for Chinese, domestic, policy, announcements, and current-news searches; use Zhipu Coding Plan MCP only when you explicitly want the Coding Plan quota route; use Context7 first for library/API/framework docs; use Exa for official domains, papers, product pages, trusted sites, and low-noise discovery; use Tavily/Firecrawl through `search --extra-sources` for horizontal candidates and through `fetch` for page evidence; use Jina for known-URL extraction; use AnySearch only when you explicitly need experimental vertical-domain search.
+Routing rule of thumb: start with `search` for broad discovery and synthesis; use `research` when you want the CLI to execute the deeper evidence workflow; use Zhipu Web Search API for Chinese, domestic, policy, announcements, and current-news searches; use Zhipu Coding Plan MCP only when you explicitly want the Coding Plan quota route; use Context7 first for library/API/framework docs; use Exa for official domains, papers, product pages, trusted sites, and low-noise discovery; use Tavily/Firecrawl through `search --extra-sources` for horizontal candidates and through `fetch` for page evidence; use Jina for known-URL extraction; use AnySearch only when you explicitly need experimental vertical-domain search.
 
 ## Deep Research
 
@@ -149,14 +157,14 @@ Use normal search when you want a fast answer:
 smart-search search "React useEffect cleanup docs" --format json
 ```
 
-Use Deep Research when you want planning, decomposition, cross-checking, or strict evidence:
+Use offline Deep Research planning when you want decomposition before execution:
 
 ```powershell
 smart-search deep "OpenAI Responses API web_search vs Chat Completions search: which should I use?" --budget deep --format json
 smart-search dr "https://example.com/source" --format json
 ```
 
-Deep Research output includes:
+Planner output includes:
 
 - `mode="deep_research"` and `query_mode="deep"`;
 - `intent_signals`, such as recency, docs/API intent, known URL, claim risk, source authority, and cross-validation need;
@@ -176,6 +184,28 @@ search, exa-search, exa-similar, zhipu-search, context7-library, context7-docs, 
 ```
 
 `doctor` is preflight, not a research step. `smart-search deep` itself is offline; live research starts when an agent or user executes `steps[].command`.
+
+Use live Deep Research execution when you want the CLI to run the staged workflow:
+
+```powershell
+smart-search research "OpenAI Responses API web_search vs Chat Completions search: which should I use?" --budget deep --fallback auto --format json
+smart-search rs "https://example.com/source" --fallback off --format markdown
+```
+
+`research` runs plan -> discover -> fetch/read -> gap check -> evidence-only synthesis. It defaults to `--fallback auto`, which permits same-capability fallback even when a normal `search` configuration is conservative. `--fallback off` tries only the first provider selected inside each capability, which is useful for debugging provider behavior.
+
+Research JSON includes `final_answer`, `citations`, `evidence_items`, `gap_check`, `provider_attempts`, `fallback_used`, `degraded`, `route_policy_version`, and `evidence_dir`. Discovery snippets are candidates only; citations are produced only from fetched/read evidence. If fallback cannot close a gap, `research` finishes degraded and lists unsupported gaps instead of inventing evidence.
+
+The research router is capability-first plus provider-advantage:
+
+- Context7 first for library/API/framework docs, with Exa as official-domain, paper, product, or trusted low-noise discovery.
+- Zhipu Web Search API first for Chinese, domestic, current, policy, and announcement searches.
+- Zhipu Coding Plan MCP remains a separate quota route through `webSearchPrime` and `webReader`.
+- Jina is favored for known public URLs, PDFs, and arXiv extraction; ReaderLM-v2 still requires `JINA_API_KEY`.
+- Firecrawl is favored for JS-heavy, dynamic, browser-like, OCR/PDF, or robust fallback extraction.
+- AnySearch participates only when vertical intent is clear, such as CVE, finance, legal, academic, or codebase/repository searches.
+
+Advanced routing overrides are available through `SMART_SEARCH_RESEARCH_PREFERRED_PROVIDERS` and `SMART_SEARCH_RESEARCH_DISABLED_PROVIDERS`. They can reorder or disable registered providers inside their supported capability, but they cannot move a provider across capability boundaries.
 
 Good user-facing smoke prompts:
 
@@ -268,6 +298,7 @@ Local config path:
 - Windows default: `%LOCALAPPDATA%\smart-search\config.json`.
 - Linux/macOS default: `~/.config/smart-search/config.json`.
 - `SMART_SEARCH_CONFIG_DIR` is an advanced override for CI, containers, sandboxes, or portable installs.
+- `SMART_SEARCH_RESEARCH_PREFERRED_PROVIDERS` and `SMART_SEARCH_RESEARCH_DISABLED_PROVIDERS` are advanced `research` routing overrides. They accept provider CSV values and can only reorder or disable providers inside existing capability boundaries.
 - Earlier Windows source builds defaulted to `~\.config\smart-search\config.json`, while some installs were already pinned to `%LOCALAPPDATA%\smart-search` through `SMART_SEARCH_CONFIG_DIR`. If the new Windows default file is missing but the old home config exists, Smart Search reads the old file as `legacy_windows_home` so upgrades do not lose configuration. `doctor` reports the active path, default path, old home path, `SMART_SEARCH_CONFIG_DIR`, and whether that override merely matches the current default.
 
 Provider timeouts:
@@ -282,6 +313,7 @@ Provider timeouts:
 | --- | --- | --- |
 | `search` | `s` | Fast live search and broad synthesis |
 | `deep` | `dr` | Offline Deep Research plan |
+| `research` | `rs` | Live Deep Research execution |
 | `fetch` | `f` | Fetch one URL as JSON, Markdown, or content |
 | `map` | `m` | Map a website structure |
 | `exa-search` | `exa`, `x` | Exa source discovery |
@@ -310,6 +342,7 @@ Useful examples:
 
 ```powershell
 smart-search search "query" --validation balanced --extra-sources 3 --timeout 90 --format json --output result.json
+smart-search research "query" --budget deep --fallback auto --format json --output research.json
 smart-search search "query" --stream --format json
 smart-search search "query" --no-stream --format json
 smart-search search "nba report" --format content

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Fallback is same-capability only:
 | --- | --- |
 | `main_search` | xAI Responses -> OpenAI-compatible |
 | `docs_search` | Context7 for library/API/docs intent; Exa for official domains, papers, product pages, and trusted-site discovery |
-| `web_search` | Zhipu Web Search API -> Zhipu Coding Plan MCP `webSearchPrime` -> Tavily -> Firecrawl |
+| `web_search` | Zhipu Web Search API -> Zhipu Coding Plan MCP `web_search_prime` -> Tavily -> Firecrawl |
 | `web_fetch` | Tavily -> Jina Reader with `JINA_API_KEY` -> Zhipu Coding Plan MCP `webReader` -> Firecrawl |
 
 AnySearch is intentionally not part of the `web_search` fallback chain and is not required by the `standard` minimum profile. Use its explicit commands for acceptance and boundary testing before promoting any vertical domain into a future route.
@@ -200,7 +200,7 @@ The research router is capability-first plus provider-advantage:
 
 - Context7 first for library/API/framework docs, with Exa as official-domain, paper, product, or trusted low-noise discovery.
 - Zhipu Web Search API first for Chinese, domestic, current, policy, and announcement searches.
-- Zhipu Coding Plan MCP remains a separate quota route through `webSearchPrime` and `webReader`.
+- Zhipu Coding Plan MCP remains a separate quota route through `web_search_prime` and `webReader`.
 - Jina is favored for known public URLs, PDFs, and arXiv extraction; ReaderLM-v2 still requires `JINA_API_KEY`.
 - Firecrawl is favored for JS-heavy, dynamic, browser-like, OCR/PDF, or robust fallback extraction.
 - AnySearch participates only when vertical intent is clear, such as CVE, finance, legal, academic, or codebase/repository searches.
@@ -240,7 +240,7 @@ Important boundaries:
 - Legacy `SMART_SEARCH_API_URL`, `SMART_SEARCH_API_KEY`, `SMART_SEARCH_API_MODE`, `SMART_SEARCH_MODEL`, and `SMART_SEARCH_XAI_TOOLS` are not supported config keys. Use `XAI_*` or `OPENAI_COMPATIBLE_*` explicitly.
 - Do not force xAI `web_search` / `x_search` tools or legacy `search_parameters` into the OpenAI-compatible Chat Completions route.
 - `zhipu-search` support is the Web Search API route, not Zhipu Chat Completions `tools=[web_search]`, not Search Agent, and not the MCP Server.
-- Zhipu Coding Plan support is a separate Remote MCP route. `webSearchPrime` maps to `web_search`, `webReader` maps to `web_fetch`, and zread tools map to explicit repo/docs discovery commands. It is not mixed into the existing `/paas/v4/web_search` Zhipu REST provider.
+- Zhipu Coding Plan support is a separate Remote MCP route. `web_search_prime` maps to `web_search`, `webReader` maps to `web_fetch`, and zread tools map to explicit repo/docs discovery commands. It is not mixed into the existing `/paas/v4/web_search` Zhipu REST provider.
 - Jina Reader is not a general search provider. `JINA_API_KEY` is required for Jina to count toward `standard`; `JINA_RESPOND_WITH=readerlm-v2` also requires `JINA_API_KEY`.
 - `ZHIPU_SEARCH_ENGINE` defaults to `search_std`. Supported official values include `search_std`, `search_pro`, `search_pro_sogou`, and `search_pro_quark`; custom values remain allowed for future services.
 - `TAVILY_API_URL` affects Tavily only. It does not proxy Zhipu. For Tavily Hikari / pooled endpoints, use `https://<host>/api/tavily`; setup normalizes root-host or `/mcp` inputs to that REST base.
@@ -319,7 +319,7 @@ Provider timeouts:
 | `exa-search` | `exa`, `x` | Exa source discovery |
 | `exa-similar` | `xs` | Similar pages from one URL |
 | `zhipu-search` | `z`, `zp` | Zhipu Web Search API |
-| `zhipu-mcp-search` | `zmcp-search` | Zhipu Coding Plan MCP `webSearchPrime` |
+| `zhipu-mcp-search` | `zmcp-search` | Zhipu Coding Plan MCP `web_search_prime` |
 | `zhipu-mcp-reader` | `zmcp-reader` | Zhipu Coding Plan MCP `webReader` |
 | `zhipu-mcp-search-doc` | `zmcp-doc` | Search open-source repository docs through zread MCP |
 | `zhipu-mcp-repo-structure` | `zmcp-tree` | Read repository structure through zread MCP |

--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ Important boundaries:
 - Do not force xAI `web_search` / `x_search` tools or legacy `search_parameters` into the OpenAI-compatible Chat Completions route.
 - `zhipu-search` support is the Web Search API route, not Zhipu Chat Completions `tools=[web_search]`, not Search Agent, and not the MCP Server.
 - Zhipu Coding Plan support is a separate Remote MCP route. `web_search_prime` maps to `web_search`, `webReader` maps to `web_fetch`, and zread tools map to explicit repo/docs discovery commands. It is not mixed into the existing `/paas/v4/web_search` Zhipu REST provider.
+- Zhipu Coding Plan MCP requires its own Coding Plan entitlement. A normal `ZHIPU_API_KEY` for Web Search API does not prove `zhipu-mcp-search` or zread access. If `ZHIPU_MCP_API_KEY` is absent or unauthorized, Smart Search skips those MCP providers; the `standard` minimum profile and same-capability fallback still work through the configured REST/search/fetch providers.
 - Jina Reader is not a general search provider. `JINA_API_KEY` is required for Jina to count toward `standard`; `JINA_RESPOND_WITH=readerlm-v2` also requires `JINA_API_KEY`.
 - `ZHIPU_SEARCH_ENGINE` defaults to `search_std`. Supported official values include `search_std`, `search_pro`, `search_pro_sogou`, and `search_pro_quark`; custom values remain allowed for future services.
 - `TAVILY_API_URL` affects Tavily only. It does not proxy Zhipu. For Tavily Hikari / pooled endpoints, use `https://<host>/api/tavily`; setup normalizes root-host or `/mcp` inputs to that REST base.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -206,7 +206,7 @@ smart-search deep "https://example.com/source" --format json
 | 智谱 Web Search API | 中文、国内、时效、域名过滤类来源发现 | `ZHIPU_API_KEY`、`ZHIPU_API_URL`、`ZHIPU_SEARCH_ENGINE` | [智谱联网搜索文档](https://docs.bigmodel.cn/cn/guide/tools/web-search) | [智谱 API keys](https://open.bigmodel.cn/usercenter/apikeys) |
 | Tavily | 额外来源、URL fetch、站点 map | `TAVILY_API_URL`、`TAVILY_API_KEY` | [Tavily docs](https://docs.tavily.com/) | [Tavily app](https://app.tavily.com/home) |
 | Firecrawl | fetch 兜底、补充网页来源 | `FIRECRAWL_API_URL`、`FIRECRAWL_API_KEY` | [Firecrawl docs](https://docs.firecrawl.dev/) | [Firecrawl API keys](https://www.firecrawl.dev/app/api-keys) |
-| AnySearch | 实验垂直搜索验收入口，不是默认兜底 | `ANYSEARCH_API_URL`、`ANYSEARCH_API_KEY`、`ANYSEARCH_TIMEOUT_SECONDS` | 服务商文档 | AnySearch 控制台 / 服务商控制台 |
+| AnySearch | 实验垂直搜索验收入口，不是默认兜底 | `ANYSEARCH_API_URL`、`ANYSEARCH_API_KEY`、`ANYSEARCH_TIMEOUT_SECONDS` | [AnySearch 文档](https://www.anysearch.com/docs) | [AnySearch API keys](https://www.anysearch.com/console/api-keys) |
 
 几个容易混淆的点：
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -109,8 +109,8 @@ Trellis、hooks、agents 或 commands。
 | --- | --- | --- | --- |
 | `main_search` | `search` | xAI Responses、OpenAI-compatible Chat Completions | 综合回答、快速搜索、初步总结 |
 | `docs_search` | `context7-library`、`context7-docs`、`exa-search` | Context7、Exa | 官方文档、SDK、API、框架/库文档 |
-| `web_search` | `zhipu-search`、`search` 内部意图补强 | 智谱、Tavily、Firecrawl | 中文、国内、时效、域名过滤、补充来源 |
-| `web_fetch` | `fetch` | Tavily、Firecrawl | 已知 URL 正文抓取、证据提取 |
+| `web_search` | `zhipu-search`、`zhipu-mcp-search`、`search` 内部意图补强 | 智谱 Web Search API、智谱 Coding Plan MCP、Tavily、Firecrawl | 中文、国内、时效、域名过滤、补充来源 |
+| `web_fetch` | `fetch`、`zhipu-mcp-reader` | Tavily、Jina Reader、智谱 Coding Plan MCP Reader、Firecrawl | 已知 URL 正文抓取、证据提取 |
 | `vertical_search` | `anysearch-domains`、`anysearch-search`、`anysearch-extract`、`anysearch-batch` | AnySearch（实验） | 验收 CVE、金融、法律、学术、代码/文档等结构化垂直域 |
 | `site_map` | `map` | Tavily | 文档站、产品站、目录型站点结构 |
 | `deep_planner` | `deep` / `dr` | 本地 planner | 离线生成 Deep Research 计划，不默认联网 |
@@ -121,10 +121,12 @@ Trellis、hooks、agents 或 commands。
 | --- | --- |
 | `main_search` | xAI Responses -> OpenAI-compatible |
 | `docs_search` | Context7 处理库/API/文档意图；Exa 处理官方域名、论文、产品页、可信站点发现 |
-| `web_search` | 智谱 -> Tavily -> Firecrawl |
-| `web_fetch` | Tavily -> Firecrawl |
+| `web_search` | 智谱 Web Search API -> 智谱 Coding Plan MCP `webSearchPrime` -> Tavily -> Firecrawl |
+| `web_fetch` | Tavily -> 带 `JINA_API_KEY` 的 Jina Reader -> 智谱 Coding Plan MCP `webReader` -> Firecrawl |
 
 AnySearch 当前只作为实验 `vertical_search` 暴露，不进入 `web_search` 兜底链，也不是 `standard` 最低配置要求。请先用显式命令做验收和能力边界判断，再决定未来是否把某个垂直域提升成正式路线。
+
+Jina Reader 只属于 `web_fetch`，不是通用搜索 provider。只有配置 `JINA_API_KEY` 后，它才可以满足 `SMART_SEARCH_MINIMUM_PROFILE=standard`；匿名 `r.jina.ai` 只能当显式/实验抓取能力，不能让最低配置检查放松。
 
 这里有一个重要边界：兜底只在同一类能力里发生。不会用 Context7 去查普通新闻，也不会用 Firecrawl 假装做文档语义检索。
 
@@ -142,7 +144,7 @@ AnySearch 当前只作为实验 `vertical_search` 暴露，不进入 `web_search
 
 `extra_sources` 只是候选来源，不等于自动事实校验。新闻、政策、财经、医疗、严肃评测、工具选型等高风险问题，建议先发现来源，再 `fetch` 关键网页正文，最后只基于抓到的正文写结论。
 
-搜索引擎选择速记：先用 `search` 做宽泛探索和综合；中文、国内、政策、公告、当前新闻优先补 `zhipu-search`；库/API/框架文档优先用 Context7；官方域名、论文、产品页、可信站点和低噪声发现再用 Exa；Tavily/Firecrawl 通过 `search --extra-sources` 做横向候选，通过 `fetch` 做正文证据；AnySearch 只在明确要实验性垂直搜索时使用。
+搜索引擎选择速记：先用 `search` 做宽泛探索和综合；中文、国内、政策、公告、当前新闻优先补 `zhipu-search`；只有明确要用 Coding Plan 额度时才走 `zhipu-mcp-*`；库/API/框架文档优先用 Context7；官方域名、论文、产品页、可信站点和低噪声发现再用 Exa；Tavily/Firecrawl 通过 `search --extra-sources` 做横向候选，通过 `fetch` 做正文证据；Jina 用于已知 URL 正文抓取；AnySearch 只在明确要实验性垂直搜索时使用。
 
 ## Deep Research 深度搜索
 
@@ -204,7 +206,9 @@ smart-search deep "https://example.com/source" --format json
 | Exa | 官方文档、API、论文、产品页、可信网页的低噪声发现 | `EXA_API_KEY` | [Exa docs](https://docs.exa.ai/) | [Exa API keys](https://dashboard.exa.ai/api-keys) |
 | Context7 | SDK、库、框架、API 文档兜底 | `CONTEXT7_API_KEY`、`CONTEXT7_BASE_URL` | [Context7 docs](https://context7.com/docs) | [Context7](https://context7.com/) |
 | 智谱 Web Search API | 中文、国内、时效、域名过滤类来源发现 | `ZHIPU_API_KEY`、`ZHIPU_API_URL`、`ZHIPU_SEARCH_ENGINE` | [智谱联网搜索文档](https://docs.bigmodel.cn/cn/guide/tools/web-search) | [智谱 API keys](https://open.bigmodel.cn/usercenter/apikeys) |
+| 智谱 Coding Plan Remote MCP | 使用 Coding Plan 额度做联网搜索、网页读取、开源仓库发现 | `ZHIPU_MCP_API_KEY`、`ZHIPU_MCP_SEARCH_API_URL`、`ZHIPU_MCP_READER_API_URL`、`ZHIPU_MCP_ZREAD_API_URL` | [联网搜索 MCP](https://docs.bigmodel.cn/cn/coding-plan/mcp/search-mcp-server)、[网页读取 MCP](https://docs.bigmodel.cn/cn/coding-plan/mcp/reader-mcp-server)、[zread MCP](https://docs.bigmodel.cn/cn/coding-plan/mcp/zread-mcp-server) | [智谱 API keys](https://open.bigmodel.cn/usercenter/apikeys) |
 | Tavily | 额外来源、URL fetch、站点 map | `TAVILY_API_URL`、`TAVILY_API_KEY` | [Tavily docs](https://docs.tavily.com/) | [Tavily app](https://app.tavily.com/home) |
+| Jina Reader | 已知 URL 正文抓取；满足 standard 最低配置必须有 key | `JINA_API_KEY`、`JINA_READER_API_URL`、`JINA_RESPOND_WITH`、`JINA_TIMEOUT_SECONDS` | [Jina Reader](https://jina.ai/reader/) | [Jina AI](https://jina.ai/) |
 | Firecrawl | fetch 兜底、补充网页来源 | `FIRECRAWL_API_URL`、`FIRECRAWL_API_KEY` | [Firecrawl docs](https://docs.firecrawl.dev/) | [Firecrawl API keys](https://www.firecrawl.dev/app/api-keys) |
 | AnySearch | 实验垂直搜索验收入口，不是默认兜底 | `ANYSEARCH_API_URL`、`ANYSEARCH_API_KEY`、`ANYSEARCH_TIMEOUT_SECONDS` | [AnySearch 文档](https://www.anysearch.com/docs) | [AnySearch API keys](https://www.anysearch.com/console/api-keys) |
 
@@ -214,7 +218,9 @@ smart-search deep "https://example.com/source" --format json
 - `OPENAI_COMPATIBLE_STREAM=true` 或 `smart-search search --stream` 只会给 OpenAI-compatible 的 `search` 和 provider 侧 `fetch` 设置 `stream=true`。它是中转长请求兼容开关，不改变 xAI Responses、URL 描述和来源排序行为。
 - 旧的 `SMART_SEARCH_API_URL`、`SMART_SEARCH_API_KEY`、`SMART_SEARCH_API_MODE`、`SMART_SEARCH_MODEL`、`SMART_SEARCH_XAI_TOOLS` 不再是受支持配置项。请显式使用 `XAI_*` 或 `OPENAI_COMPATIBLE_*`。
 - 不要给 OpenAI-compatible Chat Completions 中转强塞 xAI 的 `web_search` / `x_search` 工具或旧 `search_parameters`。
-- 当前项目里的智谱是 Web Search API，不是 Chat Completions `tools=[web_search]`，不是 Search Agent，也不是 MCP Server。
+- `zhipu-search` 对应的是智谱 Web Search API，不是 Chat Completions `tools=[web_search]`，不是 Search Agent，也不是 MCP Server。
+- 智谱 Coding Plan 是单独的 Remote MCP 路线：`webSearchPrime` 对应 `web_search`，`webReader` 对应 `web_fetch`，zread 工具对应显式仓库/文档发现命令。它不会混进现有 `/paas/v4/web_search` 智谱 REST provider。
+- Jina Reader 不是通用搜索 provider。只有配置 `JINA_API_KEY` 后才计入 `standard`；`JINA_RESPOND_WITH=readerlm-v2` 也必须配置 `JINA_API_KEY`。
 - `ZHIPU_SEARCH_ENGINE` 默认是 `search_std`。官方值包括 `search_std`、`search_pro`、`search_pro_sogou`、`search_pro_quark`；`config set` 仍允许自定义值，方便官方以后新增服务。
 - `TAVILY_API_URL` 只影响 Tavily，不会代理智谱。Tavily Hikari / 号池用 `https://<host>/api/tavily`；setup 会把根域名或 `/mcp` 输入规范化成这个 REST base。
 - `FIRECRAWL_API_URL` 默认是 `https://api.firecrawl.dev/v2`。
@@ -238,6 +244,8 @@ smart-search setup --non-interactive `
   --zhipu-key "your-zhipu-key" `
   --zhipu-api-url "https://open.bigmodel.cn/api" `
   --zhipu-search-engine "search_pro_sogou" `
+  --zhipu-mcp-key "your-zhipu-coding-plan-key" `
+  --jina-key "your-jina-key" `
   --tavily-api-url "https://api.tavily.com" `
   --tavily-key "your-tavily-key" `
   --firecrawl-api-url "https://api.firecrawl.dev/v2" `
@@ -248,7 +256,7 @@ smart-search setup --non-interactive `
 
 - `main_search`：xAI Responses 或 OpenAI-compatible 二选一；
 - `docs_search`：Exa 或 Context7 二选一；
-- `web_fetch`：Tavily 或 Firecrawl 二选一。
+- `web_fetch`：Tavily、带 `JINA_API_KEY` 的 Jina、智谱 Coding Plan MCP Reader、Firecrawl 四选一。
 
 缺少任一最低能力时，`doctor` 和 `search` 会 fail closed 并返回缺失 capability。`SMART_SEARCH_MINIMUM_PROFILE=off` 只建议本地实验使用。
 
@@ -291,6 +299,15 @@ smart-search anysearch-batch "AAPL" "RAG papers" --max-results 2 --format json
 | `ZHIPU_API_KEY` | 智谱 Web Search key |
 | `ZHIPU_API_URL` | 智谱 API 地址，默认 `https://open.bigmodel.cn/api` |
 | `ZHIPU_SEARCH_ENGINE` | 智谱搜索服务，例如 `search_pro_sogou` |
+| `ZHIPU_MCP_API_KEY` | 智谱 Coding Plan Remote MCP key |
+| `ZHIPU_MCP_SEARCH_API_URL` | 智谱 Coding Plan 联网搜索 MCP endpoint |
+| `ZHIPU_MCP_READER_API_URL` | 智谱 Coding Plan 网页读取 MCP endpoint |
+| `ZHIPU_MCP_ZREAD_API_URL` | 智谱 Coding Plan zread MCP endpoint |
+| `ZHIPU_MCP_TIMEOUT_SECONDS` | 智谱 Coding Plan MCP 请求超时，默认 `30` |
+| `JINA_API_KEY` | Jina Reader key；满足 standard 必须配置 |
+| `JINA_READER_API_URL` | Jina Reader endpoint，默认 `https://r.jina.ai` |
+| `JINA_RESPOND_WITH` | Jina Reader 响应模式，例如 `readerlm-v2`；需要 `JINA_API_KEY` |
+| `JINA_TIMEOUT_SECONDS` | Jina Reader 请求超时，默认 `30` |
 | `TAVILY_API_URL` | Tavily REST base |
 | `TAVILY_API_KEY` | Tavily key |
 | `TAVILY_TIMEOUT_SECONDS` | Tavily 连通性检查超时，默认 `30`；公益站/号池较慢时可调大 |
@@ -311,6 +328,11 @@ smart-search anysearch-batch "AAPL" "RAG papers" --max-results 2 --format json
 | `exa-search` | `exa`、`x` | Exa 来源发现 |
 | `exa-similar` | `xs` | 从一个 URL 找相似页面 |
 | `zhipu-search` | `z`、`zp` | 智谱 Web Search API |
+| `zhipu-mcp-search` | `zmcp-search` | 智谱 Coding Plan MCP `webSearchPrime` |
+| `zhipu-mcp-reader` | `zmcp-reader` | 智谱 Coding Plan MCP `webReader` |
+| `zhipu-mcp-search-doc` | `zmcp-doc` | 通过 zread MCP 搜开源仓库文档 |
+| `zhipu-mcp-repo-structure` | `zmcp-tree` | 通过 zread MCP 读仓库结构 |
+| `zhipu-mcp-read-file` | `zmcp-file` | 通过 zread MCP 读单个仓库文件 |
 | `anysearch-domains` | `as-domains` | 实验 AnySearch 域名/能力发现 |
 | `anysearch-search` | `as-search`、`as` | 实验 AnySearch 垂直/通用搜索 |
 | `anysearch-extract` | `as-extract` | 实验 AnySearch URL 抽取 |
@@ -335,6 +357,9 @@ smart-search exa-search "OpenAI Responses API documentation" --include-domains p
 smart-search context7-library "react" "hooks" --format json
 smart-search context7-docs "/facebook/react" "useEffect cleanup" --format json
 smart-search zhipu-search "今天国内 AI 新闻" --search-engine search_pro_sogou --count 5 --format json
+smart-search zhipu-mcp-search "今天国内 AI 新闻" --count 5 --format json
+smart-search zhipu-mcp-reader "https://example.com/source" --format json
+smart-search zhipu-mcp-search-doc "owner/repo" "install" --format json
 smart-search anysearch-search "CVE-2024-3094" --domain security.cve --max-results 3 --format json
 smart-search anysearch-extract "https://example.com/source" --format json
 smart-search exa-similar "https://example.com/source" --num-results 5 --format json

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -2,7 +2,7 @@
 
 简体中文 | [English](README.md)
 
-`smart-search` 是一个给 AI 助手和命令行用户使用的 CLI-first 网页研究工具。它把普通联网搜索、来源发现、网页正文抓取、站点 map、配置检查和 Deep Research 规划统一成一个可复现的命令层。
+`smart-search` 是一个给 AI 助手和命令行用户使用的 CLI-first 网页研究工具。它把普通联网搜索、来源发现、网页正文抓取、站点 map、配置检查、Deep Research 离线规划和 live Deep Research 执行统一成一个可复现的命令层。
 
 <p>
   <a href="https://www.npmjs.com/package/@konbakuyomu/smart-search">
@@ -20,6 +20,7 @@
 smart-search search "今天 OpenAI Responses API 有什么新变化" --format json
 smart-search fetch "https://example.com/article" --format markdown
 smart-search deep "OpenAI Responses API web_search 和 Chat Completions 联网搜索怎么选" --format json
+smart-search research "OpenAI Responses API web_search 和 Chat Completions 联网搜索怎么选" --format markdown
 ```
 
 当前架构分两层：
@@ -29,7 +30,7 @@ smart-search deep "OpenAI Responses API web_search 和 Chat Completions 联网�
 | CLI 执行层 | 稳定执行命令、provider 路由、同能力兜底、JSON/Markdown 输出、本机配置、smoke/regression |
 | Skill / AI 编排层 | 判断用户意图，决定普通搜索还是 Deep Research，按计划执行 CLI 积木，最后写出有来源支撑的回答 |
 
-`smart-search search` 保持快速、直接联网。`smart-search deep` 是显式 Deep Research 离线规划入口：默认不联网、不跑 provider、不抓网页，只输出 `research_plan`。真正联网发生在 AI 或用户继续执行 `steps[].command` 的时候。
+`smart-search search` 保持快速、直接联网。`smart-search deep` 是显式 Deep Research 离线规划入口：默认不联网、不跑 provider、不抓网页，只输出 `research_plan`。真正联网可以由 AI 或用户继续执行 `steps[].command`，也可以交给新的 `smart-search research` live 执行器完成。`research` 会按 plan -> discover -> fetch/read -> gap check -> evidence-only synthesis 执行。
 
 ## 安装
 
@@ -82,7 +83,13 @@ smart-search fetch "https://example.com/source" --format markdown --output evide
 smart-search deep "深度搜索一下最近的比特币行情" --budget standard --format json
 ```
 
-5. 把 skill 安装给 AI 工具：
+5. 让 CLI 直接执行 live Deep Research：
+
+```powershell
+smart-search research "深度搜索一下最近的比特币行情" --budget deep --format markdown
+```
+
+6. 把 skill 安装给 AI 工具：
 
 ```powershell
 smart-search setup --non-interactive --install-skills codex,claude,cursor,hermes
@@ -92,7 +99,7 @@ Skill 安装会把内置 `smart-search-cli` 写入用户级工具目录，例如
 `~/.claude/skills`、`~/.cursor/skills`、`~/.hermes/skills`。它不会初始化 Trellis、hooks、
 agents 或 commands。`--skills-root PATH` 只适合便携安装或测试时高级覆盖根目录。
 
-6. 升级 CLI 后，同步已经安装到全局 AI 工具里的 skill：
+7. 升级 CLI 后，同步已经安装到全局 AI 工具里的 skill：
 
 ```powershell
 smart-search skills status --targets codex --format json
@@ -114,6 +121,7 @@ Trellis、hooks、agents 或 commands。
 | `vertical_search` | `anysearch-domains`、`anysearch-search`、`anysearch-extract`、`anysearch-batch` | AnySearch（实验） | 验收 CVE、金融、法律、学术、代码/文档等结构化垂直域 |
 | `site_map` | `map` | Tavily | 文档站、产品站、目录型站点结构 |
 | `deep_planner` | `deep` / `dr` | 本地 planner | 离线生成 Deep Research 计划，不默认联网 |
+| `research_executor` | `research` / `rs` | 按 capability 注册的 provider | live 深度研究执行：规划、发现、抓取/读取、gap check、仅基于证据综合 |
 
 同能力兜底关系：
 
@@ -144,7 +152,7 @@ Jina Reader 只属于 `web_fetch`，不是通用搜索 provider。只有配置 `
 
 `extra_sources` 只是候选来源，不等于自动事实校验。新闻、政策、财经、医疗、严肃评测、工具选型等高风险问题，建议先发现来源，再 `fetch` 关键网页正文，最后只基于抓到的正文写结论。
 
-搜索引擎选择速记：先用 `search` 做宽泛探索和综合；中文、国内、政策、公告、当前新闻优先补 `zhipu-search`；只有明确要用 Coding Plan 额度时才走 `zhipu-mcp-*`；库/API/框架文档优先用 Context7；官方域名、论文、产品页、可信站点和低噪声发现再用 Exa；Tavily/Firecrawl 通过 `search --extra-sources` 做横向候选，通过 `fetch` 做正文证据；Jina 用于已知 URL 正文抓取；AnySearch 只在明确要实验性垂直搜索时使用。
+搜索引擎选择速记：先用 `search` 做宽泛探索和综合；想让 CLI 执行完整证据流时用 `research`；中文、国内、政策、公告、当前新闻优先补 `zhipu-search`；只有明确要用 Coding Plan 额度时才走 `zhipu-mcp-*`；库/API/框架文档优先用 Context7；官方域名、论文、产品页、可信站点和低噪声发现再用 Exa；Tavily/Firecrawl 通过 `search --extra-sources` 做横向候选，通过 `fetch` 做正文证据；Jina 用于已知 URL 正文抓取；AnySearch 只在明确要实验性垂直搜索时使用。
 
 ## Deep Research 深度搜索
 
@@ -154,7 +162,7 @@ Jina Reader 只属于 `web_fetch`，不是通用搜索 provider。只有配置 `
 smart-search search "React useEffect cleanup 文档" --format json
 ```
 
-需要深度搜索、拆解、核验、选型、严肃评测、多来源交叉验证时用：
+需要先拆解、规划、再由你或 AI 分步执行时用：
 
 ```powershell
 smart-search deep "OpenAI Responses API web_search 和 Chat Completions 联网搜索怎么选" --budget deep --format json
@@ -183,6 +191,28 @@ search, exa-search, exa-similar, zhipu-search, context7-library, context7-docs, 
 `doctor` 是 preflight 配置预检，不是 research step。`smart-search deep` 这一步本身是离线 planner；后续执行计划里的 `steps[].command` 时才会联网。
 
 换句话说，`doctor` 只是配置预检；它帮助 AI 判断当前 provider 是否可用，但不算 Deep Research 的取证步骤。
+
+如果你希望 CLI 直接执行完整 live Deep Research，用：
+
+```powershell
+smart-search research "OpenAI Responses API web_search 和 Chat Completions 联网搜索怎么选" --budget deep --fallback auto --format json
+smart-search rs "https://example.com/source" --fallback off --format markdown
+```
+
+`research` 会执行 plan -> discover -> fetch/read -> gap check -> evidence-only synthesis。默认 `--fallback auto`，会在同一 capability 内兜底；`--fallback off` 只尝试每个 capability 选中的第一个 provider，适合手动调试某个 provider。
+
+`research` JSON 会包含 `final_answer`、`citations`、`evidence_items`、`gap_check`、`provider_attempts`、`fallback_used`、`degraded`、`route_policy_version` 和 `evidence_dir`。发现阶段的 snippet 只是候选，不会直接变成 citation；只有 fetch/read 到正文的来源才会被引用。兜底仍然补不齐证据时，`research` 会降级输出 gap，不会编造结论。
+
+`research` 的路由是 capability-first 加 provider 优势：
+
+- Context7 优先处理库/API/框架文档，Exa 用于官方域名、论文、产品页、可信站点和低噪声发现。
+- 智谱 Web Search API 优先处理中文、国内、时效、政策、公告搜索。
+- 智谱 Coding Plan MCP 仍是单独额度路线，通过 `webSearchPrime` 和 `webReader` 加入对应 capability。
+- Jina 优先用于已知公开 URL、PDF、arXiv 正文抽取；ReaderLM-v2 仍要求 `JINA_API_KEY`。
+- Firecrawl 优先用于 JS-heavy、动态页面、浏览器式抽取、OCR/PDF 或强兜底抓取。
+- AnySearch 只在垂直意图清楚时加入，例如 CVE、金融、法律、学术、代码库/仓库搜索。
+
+高级路由覆盖项是 `SMART_SEARCH_RESEARCH_PREFERRED_PROVIDERS` 和 `SMART_SEARCH_RESEARCH_DISABLED_PROVIDERS`。它们只能在 provider 已支持的 capability 内调整顺序或禁用，不能把 provider 移到另一个 capability。
 
 可以用这些标准问题测试是否进入深搜模式：
 
@@ -315,6 +345,8 @@ smart-search anysearch-batch "AAPL" "RAG papers" --max-results 2 --format json
 | `FIRECRAWL_API_KEY` | Firecrawl key |
 | `SMART_SEARCH_VALIDATION_LEVEL` | `fast`、`balanced`、`strict` |
 | `SMART_SEARCH_FALLBACK_MODE` | `auto` 或 `off` |
+| `SMART_SEARCH_RESEARCH_PREFERRED_PROVIDERS` | `research` 路由优先 provider CSV，只能在同 capability 内调整顺序 |
+| `SMART_SEARCH_RESEARCH_DISABLED_PROVIDERS` | `research` 禁用 provider CSV，不能改变 provider capability 边界 |
 | `SMART_SEARCH_CONFIG_DIR` | 指定本机配置和日志根目录 |
 
 ## 常用命令
@@ -323,6 +355,7 @@ smart-search anysearch-batch "AAPL" "RAG papers" --max-results 2 --format json
 | --- | --- | --- |
 | `search` | `s` | 快速联网搜索和综合回答 |
 | `deep` | `dr` | Deep Research 离线计划 |
+| `research` | `rs` | live Deep Research 执行 |
 | `fetch` | `f` | 抓一个 URL 正文 |
 | `map` | `m` | 读取站点结构 |
 | `exa-search` | `exa`、`x` | Exa 来源发现 |
@@ -350,6 +383,7 @@ smart-search anysearch-batch "AAPL" "RAG papers" --max-results 2 --format json
 
 ```powershell
 smart-search search "query" --validation balanced --extra-sources 3 --timeout 90 --format json --output result.json
+smart-search research "query" --budget deep --fallback auto --format json --output research.json
 smart-search search "query" --stream --format json
 smart-search search "query" --no-stream --format json
 smart-search search "nba战报" --format content

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -129,7 +129,7 @@ Trellis、hooks、agents 或 commands。
 | --- | --- |
 | `main_search` | xAI Responses -> OpenAI-compatible |
 | `docs_search` | Context7 处理库/API/文档意图；Exa 处理官方域名、论文、产品页、可信站点发现 |
-| `web_search` | 智谱 Web Search API -> 智谱 Coding Plan MCP `webSearchPrime` -> Tavily -> Firecrawl |
+| `web_search` | 智谱 Web Search API -> 智谱 Coding Plan MCP `web_search_prime` -> Tavily -> Firecrawl |
 | `web_fetch` | Tavily -> 带 `JINA_API_KEY` 的 Jina Reader -> 智谱 Coding Plan MCP `webReader` -> Firecrawl |
 
 AnySearch 当前只作为实验 `vertical_search` 暴露，不进入 `web_search` 兜底链，也不是 `standard` 最低配置要求。请先用显式命令做验收和能力边界判断，再决定未来是否把某个垂直域提升成正式路线。
@@ -207,7 +207,7 @@ smart-search rs "https://example.com/source" --fallback off --format markdown
 
 - Context7 优先处理库/API/框架文档，Exa 用于官方域名、论文、产品页、可信站点和低噪声发现。
 - 智谱 Web Search API 优先处理中文、国内、时效、政策、公告搜索。
-- 智谱 Coding Plan MCP 仍是单独额度路线，通过 `webSearchPrime` 和 `webReader` 加入对应 capability。
+- 智谱 Coding Plan MCP 仍是单独额度路线，通过 `web_search_prime` 和 `webReader` 加入对应 capability。
 - Jina 优先用于已知公开 URL、PDF、arXiv 正文抽取；ReaderLM-v2 仍要求 `JINA_API_KEY`。
 - Firecrawl 优先用于 JS-heavy、动态页面、浏览器式抽取、OCR/PDF 或强兜底抓取。
 - AnySearch 只在垂直意图清楚时加入，例如 CVE、金融、法律、学术、代码库/仓库搜索。
@@ -249,7 +249,7 @@ smart-search deep "https://example.com/source" --format json
 - 旧的 `SMART_SEARCH_API_URL`、`SMART_SEARCH_API_KEY`、`SMART_SEARCH_API_MODE`、`SMART_SEARCH_MODEL`、`SMART_SEARCH_XAI_TOOLS` 不再是受支持配置项。请显式使用 `XAI_*` 或 `OPENAI_COMPATIBLE_*`。
 - 不要给 OpenAI-compatible Chat Completions 中转强塞 xAI 的 `web_search` / `x_search` 工具或旧 `search_parameters`。
 - `zhipu-search` 对应的是智谱 Web Search API，不是 Chat Completions `tools=[web_search]`，不是 Search Agent，也不是 MCP Server。
-- 智谱 Coding Plan 是单独的 Remote MCP 路线：`webSearchPrime` 对应 `web_search`，`webReader` 对应 `web_fetch`，zread 工具对应显式仓库/文档发现命令。它不会混进现有 `/paas/v4/web_search` 智谱 REST provider。
+- 智谱 Coding Plan 是单独的 Remote MCP 路线：`web_search_prime` 对应 `web_search`，`webReader` 对应 `web_fetch`，zread 工具对应显式仓库/文档发现命令。它不会混进现有 `/paas/v4/web_search` 智谱 REST provider。
 - Jina Reader 不是通用搜索 provider。只有配置 `JINA_API_KEY` 后才计入 `standard`；`JINA_RESPOND_WITH=readerlm-v2` 也必须配置 `JINA_API_KEY`。
 - `ZHIPU_SEARCH_ENGINE` 默认是 `search_std`。官方值包括 `search_std`、`search_pro`、`search_pro_sogou`、`search_pro_quark`；`config set` 仍允许自定义值，方便官方以后新增服务。
 - `TAVILY_API_URL` 只影响 Tavily，不会代理智谱。Tavily Hikari / 号池用 `https://<host>/api/tavily`；setup 会把根域名或 `/mcp` 输入规范化成这个 REST base。
@@ -361,7 +361,7 @@ smart-search anysearch-batch "AAPL" "RAG papers" --max-results 2 --format json
 | `exa-search` | `exa`、`x` | Exa 来源发现 |
 | `exa-similar` | `xs` | 从一个 URL 找相似页面 |
 | `zhipu-search` | `z`、`zp` | 智谱 Web Search API |
-| `zhipu-mcp-search` | `zmcp-search` | 智谱 Coding Plan MCP `webSearchPrime` |
+| `zhipu-mcp-search` | `zmcp-search` | 智谱 Coding Plan MCP `web_search_prime` |
 | `zhipu-mcp-reader` | `zmcp-reader` | 智谱 Coding Plan MCP `webReader` |
 | `zhipu-mcp-search-doc` | `zmcp-doc` | 通过 zread MCP 搜开源仓库文档 |
 | `zhipu-mcp-repo-structure` | `zmcp-tree` | 通过 zread MCP 读仓库结构 |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -250,6 +250,7 @@ smart-search deep "https://example.com/source" --format json
 - 不要给 OpenAI-compatible Chat Completions 中转强塞 xAI 的 `web_search` / `x_search` 工具或旧 `search_parameters`。
 - `zhipu-search` 对应的是智谱 Web Search API，不是 Chat Completions `tools=[web_search]`，不是 Search Agent，也不是 MCP Server。
 - 智谱 Coding Plan 是单独的 Remote MCP 路线：`web_search_prime` 对应 `web_search`，`webReader` 对应 `web_fetch`，zread 工具对应显式仓库/文档发现命令。它不会混进现有 `/paas/v4/web_search` 智谱 REST provider。
+- 智谱 Coding Plan MCP 需要单独的 Coding Plan 权益。普通 `ZHIPU_API_KEY` 能用 Web Search API，不代表能用 `zhipu-mcp-search` 或 zread。未配置或未授权 `ZHIPU_MCP_API_KEY` 时，Smart Search 会跳过这些 MCP provider；`standard` 最低配置和同 capability 兜底仍会通过已配置的 REST/search/fetch provider 工作。
 - Jina Reader 不是通用搜索 provider。只有配置 `JINA_API_KEY` 后才计入 `standard`；`JINA_RESPOND_WITH=readerlm-v2` 也必须配置 `JINA_API_KEY`。
 - `ZHIPU_SEARCH_ENGINE` 默认是 `search_std`。官方值包括 `search_std`、`search_pro`、`search_pro_sogou`、`search_pro_quark`；`config set` 仍允许自定义值，方便官方以后新增服务。
 - `TAVILY_API_URL` 只影响 Tavily，不会代理智谱。Tavily Hikari / 号池用 `https://<host>/api/tavily`；setup 会把根域名或 `/mcp` 输入规范化成这个 REST base。

--- a/scripts/test-jina-capability.ps1
+++ b/scripts/test-jina-capability.ps1
@@ -1,0 +1,301 @@
+<#
+.SYNOPSIS
+Run isolated live checks for Smart Search Jina Reader capability.
+
+.DESCRIPTION
+This script intentionally uses a temporary SMART_SEARCH_CONFIG_DIR and clears
+other web_fetch provider env vars for the current process while it runs, so
+`smart-search fetch` must use Jina instead of being satisfied by Tavily or
+Firecrawl first.
+
+It never prints the Jina key. By default it reads JINA_API_KEY from the current
+process env var or from the local Smart Search config file. You can also pass
+`-JinaApiKey` explicitly.
+
+.EXAMPLE
+powershell -ExecutionPolicy Bypass -File .\scripts\test-jina-capability.ps1
+
+.EXAMPLE
+powershell -ExecutionPolicy Bypass -File .\scripts\test-jina-capability.ps1 -Profile full -Modes default,readerlm-v2
+
+.EXAMPLE
+powershell -ExecutionPolicy Bypass -File .\scripts\test-jina-capability.ps1 -Urls "https://example.com","https://www.iana.org/help/example-domains" -Modes default
+#>
+
+[CmdletBinding()]
+param(
+    [string[]]$Urls,
+
+    [ValidateSet("quick", "full")]
+    [string]$Profile = "quick",
+
+    [ValidateSet("default", "readerlm-v2")]
+    [string[]]$Modes = @("default", "readerlm-v2"),
+
+    [string]$JinaApiKey = $env:JINA_API_KEY,
+
+    [string]$JinaReaderApiUrl = "https://r.jina.ai",
+
+    [int]$TimeoutSeconds = 60,
+
+    [string]$EvidenceDir = (Join-Path $env:TEMP ("smart-search-jina-evidence-" + (Get-Date -Format "yyyyMMdd-HHmmss"))),
+
+    [switch]$KeepOtherFetchProviders
+)
+
+$ErrorActionPreference = "Stop"
+
+function Get-SafeSlug {
+    param([Parameter(Mandatory = $true)][string]$Text)
+    $slug = $Text -replace '^https?://', ''
+    $slug = $slug -replace '[^A-Za-z0-9._-]+', '-'
+    $slug = $slug.Trim('-')
+    if ($slug.Length -gt 70) {
+        $slug = $slug.Substring(0, 70)
+    }
+    if (-not $slug) {
+        return "url"
+    }
+    return $slug
+}
+
+function Get-SmartSearchConfigValue {
+    param([Parameter(Mandatory = $true)][string]$Name)
+
+    $pathOutput = & smart-search config path --format json 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        return $null
+    }
+
+    $pathText = ($pathOutput | Out-String).Trim()
+    try {
+        $pathData = $pathText | ConvertFrom-Json
+    }
+    catch {
+        return $null
+    }
+
+    if (-not $pathData.config_file -or -not (Test-Path -LiteralPath $pathData.config_file)) {
+        return $null
+    }
+
+    try {
+        $configData = Get-Content -LiteralPath $pathData.config_file -Raw | ConvertFrom-Json
+        return $configData.$Name
+    }
+    catch {
+        return $null
+    }
+}
+
+function ConvertFrom-SmartSearchJson {
+    param(
+        [Parameter(Mandatory = $true)][string]$Text,
+        [int]$ExitCode
+    )
+
+    $trimmed = $Text.Trim()
+    $start = $trimmed.IndexOf("{")
+    $end = $trimmed.LastIndexOf("}")
+    if ($start -lt 0 -or $end -lt $start) {
+        return [pscustomobject]@{
+            ok = $false
+            error_type = "parse_error"
+            error = "smart-search did not return a JSON object"
+            exit_code = $ExitCode
+            raw = $trimmed
+        }
+    }
+
+    $jsonText = $trimmed.Substring($start, $end - $start + 1)
+    try {
+        return $jsonText | ConvertFrom-Json
+    }
+    catch {
+        return [pscustomobject]@{
+            ok = $false
+            error_type = "parse_error"
+            error = $_.Exception.Message
+            exit_code = $ExitCode
+            raw = $trimmed
+        }
+    }
+}
+
+function Invoke-SmartSearchJson {
+    param([Parameter(Mandatory = $true)][string[]]$Arguments)
+
+    $output = & smart-search @Arguments 2>&1
+    $exitCode = $LASTEXITCODE
+    $text = ($output | Out-String).Trim()
+    $data = ConvertFrom-SmartSearchJson -Text $text -ExitCode $exitCode
+    if ($null -eq $data.exit_code) {
+        $data | Add-Member -NotePropertyName exit_code -NotePropertyValue $exitCode -Force
+    }
+    return $data
+}
+
+function Save-JsonEvidence {
+    param(
+        [Parameter(Mandatory = $true)]$Data,
+        [Parameter(Mandatory = $true)][string]$Path
+    )
+
+    $Data | ConvertTo-Json -Depth 80 | Set-Content -LiteralPath $Path -Encoding utf8
+}
+
+if (-not $Urls -or $Urls.Count -eq 0) {
+    $Urls = @(
+        "https://example.com",
+        "https://www.iana.org/help/example-domains"
+    )
+
+    if ($Profile -eq "full") {
+        $Urls += @(
+            "https://www.rfc-editor.org/rfc/rfc2606.txt",
+            "https://arxiv.org/pdf/1706.03762"
+        )
+    }
+}
+
+if (-not $JinaApiKey) {
+    $JinaApiKey = Get-SmartSearchConfigValue -Name "JINA_API_KEY"
+}
+if (-not $JinaApiKey) {
+    throw "JINA_API_KEY was not found. Pass -JinaApiKey or run 'smart-search setup --non-interactive --jina-key <key>' first."
+}
+
+New-Item -ItemType Directory -Path $EvidenceDir -Force | Out-Null
+$TempConfigDir = Join-Path $env:TEMP ("smart-search-jina-config-" + [guid]::NewGuid().ToString("N"))
+New-Item -ItemType Directory -Path $TempConfigDir -Force | Out-Null
+
+$envNamesToSave = @(
+    "SMART_SEARCH_CONFIG_DIR",
+    "JINA_API_KEY",
+    "JINA_READER_API_URL",
+    "JINA_RESPOND_WITH",
+    "JINA_TIMEOUT_SECONDS"
+)
+if (-not $KeepOtherFetchProviders) {
+    $envNamesToSave += @(
+        "TAVILY_API_KEY",
+        "FIRECRAWL_API_KEY",
+        "ZHIPU_MCP_API_KEY"
+    )
+}
+
+$savedEnv = @{}
+foreach ($name in $envNamesToSave) {
+    $savedEnv[$name] = [Environment]::GetEnvironmentVariable($name, "Process")
+}
+
+try {
+    [Environment]::SetEnvironmentVariable("SMART_SEARCH_CONFIG_DIR", $TempConfigDir, "Process")
+    [Environment]::SetEnvironmentVariable("JINA_API_KEY", $JinaApiKey, "Process")
+    [Environment]::SetEnvironmentVariable("JINA_READER_API_URL", $JinaReaderApiUrl, "Process")
+    [Environment]::SetEnvironmentVariable("JINA_TIMEOUT_SECONDS", [string]$TimeoutSeconds, "Process")
+
+    if (-not $KeepOtherFetchProviders) {
+        foreach ($name in @("TAVILY_API_KEY", "FIRECRAWL_API_KEY", "ZHIPU_MCP_API_KEY")) {
+            [Environment]::SetEnvironmentVariable($name, $null, "Process")
+        }
+    }
+
+    Write-Host "Smart Search Jina capability test"
+    Write-Host "smart-search : $((& smart-search --version 2>$null) -join ' ')"
+    Write-Host "reader api   : $JinaReaderApiUrl"
+    Write-Host "timeout      : $TimeoutSeconds seconds"
+    Write-Host "temp config  : $TempConfigDir"
+    Write-Host "evidence dir : $EvidenceDir"
+    Write-Host "modes        : $($Modes -join ', ')"
+    Write-Host ""
+
+    [Environment]::SetEnvironmentVariable("JINA_RESPOND_WITH", $null, "Process")
+    $doctor = Invoke-SmartSearchJson -Arguments @("doctor", "--format", "json")
+    Save-JsonEvidence -Data $doctor -Path (Join-Path $EvidenceDir "00-doctor.json")
+
+    $doctorSummary = [pscustomobject]@{
+        ok = $doctor.ok
+        minimum_profile_ok = $doctor.minimum_profile_ok
+        web_fetch_configured = (($doctor.capability_status.web_fetch.configured | ForEach-Object { $_ }) -join ",")
+        jina_status = $doctor.jina_connection_test.status
+        missing = (($doctor.minimum_profile_missing | ForEach-Object { $_ }) -join ",")
+    }
+    Write-Host "Doctor summary"
+    $doctorSummary | Format-List
+
+    $summaries = New-Object System.Collections.Generic.List[object]
+    $caseIndex = 0
+    foreach ($mode in $Modes) {
+        if ($mode -eq "readerlm-v2") {
+            [Environment]::SetEnvironmentVariable("JINA_RESPOND_WITH", "readerlm-v2", "Process")
+        }
+        else {
+            [Environment]::SetEnvironmentVariable("JINA_RESPOND_WITH", $null, "Process")
+        }
+
+        foreach ($url in $Urls) {
+            $caseIndex += 1
+            $slug = Get-SafeSlug -Text $url
+            $jsonPath = Join-Path $EvidenceDir ("{0:D2}-{1}-{2}.json" -f $caseIndex, $mode, $slug)
+            $contentPath = Join-Path $EvidenceDir ("{0:D2}-{1}-{2}.md" -f $caseIndex, $mode, $slug)
+
+            Write-Host ("Running [{0}] mode={1} url={2}" -f $caseIndex, $mode, $url)
+            $result = Invoke-SmartSearchJson -Arguments @("fetch", $url, "--format", "json")
+            Save-JsonEvidence -Data $result -Path $jsonPath
+            if ($result.content) {
+                $result.content | Set-Content -LiteralPath $contentPath -Encoding utf8
+            }
+
+            $attempts = ""
+            if ($result.provider_attempts) {
+                $attempts = (($result.provider_attempts | ForEach-Object {
+                    "{0}:{1}:{2}" -f $_.provider, $_.status, $_.error_type
+                }) -join ",")
+            }
+
+            $content = [string]$result.content
+            $preview = $content
+            if ($preview.Length -gt 260) {
+                $preview = $preview.Substring(0, 260)
+            }
+            $preview = ($preview -replace "\s+", " ").Trim()
+
+            $summaries.Add([pscustomobject]@{
+                case = $caseIndex
+                mode = $mode
+                ok = $result.ok
+                provider = $result.provider
+                fallback = $result.fallback_used
+                content_len = $content.Length
+                attempts = $attempts
+                json = $jsonPath
+                content = $(if ($result.content) { $contentPath } else { "" })
+                preview = $preview
+            })
+        }
+    }
+
+    Write-Host ""
+    Write-Host "Fetch summary"
+    $summaries | Format-Table case, mode, ok, provider, fallback, content_len, attempts -AutoSize
+
+    Write-Host ""
+    Write-Host "Content preview"
+    foreach ($item in $summaries) {
+        Write-Host ("[{0}] {1} {2}" -f $item.case, $item.mode, $item.preview)
+        Write-Host ""
+    }
+
+    $summaryPath = Join-Path $EvidenceDir "summary.json"
+    Save-JsonEvidence -Data $summaries -Path $summaryPath
+    Write-Host "Saved summary : $summaryPath"
+    Write-Host "Saved details : $EvidenceDir"
+    Write-Host ""
+    Write-Host "Expected: provider should be 'jina'. If another provider appears, rerun without -KeepOtherFetchProviders."
+}
+finally {
+    foreach ($name in $savedEnv.Keys) {
+        [Environment]::SetEnvironmentVariable($name, $savedEnv[$name], "Process")
+    }
+}

--- a/skills/smart-search-cli/SKILL.md
+++ b/skills/smart-search-cli/SKILL.md
@@ -145,24 +145,26 @@ smart-search deep "https://example.com/source" --format json
 - Chat Completions mode must not send xAI `web_search` / `x_search` tools or legacy `search_parameters`; xAI Chat Completions Live Search is deprecated.
 - The standard minimum profile requires one configured provider in each of `main_search`, `docs_search`, and fetch capability. Missing required capabilities should be treated as a hard configuration failure.
 - AnySearch is reported only as optional experimental `vertical_search`; it is not part of the `web_search` fallback and is not required by the `standard` minimum profile.
+- Jina Reader is `web_fetch` only, not a general search provider. `JINA_API_KEY` is required before Jina satisfies the standard minimum profile; anonymous `r.jina.ai` is explicit/experimental fetch behavior.
 - `search` exposes `--validation fast|balanced|strict`, `--fallback auto|off`, and `--providers auto|CSV`. Default validation is `balanced`; fallback only happens within the same capability.
 - xAI Responses is the default main answer route for Grok/xAI. In `fallback=auto`, a failed xAI Responses main route can fall back to OpenAI-compatible only when the OpenAI-compatible provider is separately configured.
 - Docs/API/library routing should prefer Context7 first. Exa is for official-domain or low-noise supplemental discovery, not the default docs answer route.
-- Zhipu is a general web-search reinforcement and same-capability fallback for Chinese, domestic, current, or domain-filtered source discovery.
+- Zhipu Web Search API is a general web-search reinforcement and same-capability fallback for Chinese, domestic, current, or domain-filtered source discovery.
+- Zhipu Coding Plan Remote MCP is a separate route: `webSearchPrime` maps to `web_search`, `webReader` maps to `web_fetch`, and zread tools map to explicit repo/docs discovery commands. Do not mix it into the existing `/paas/v4/web_search` REST provider.
 - `search` calls Tavily and/or Firecrawl only when `--extra-sources N` is greater than 0.
 - With both Tavily and Firecrawl configured, `search --extra-sources N` splits extra sources between them, with Tavily receiving about 60% and Firecrawl the rest.
 - Search JSON separates `primary_sources`, `extra_sources`, and backward-compatible merged `sources`.
 - `primary_sources` are extracted from the primary model answer. `extra_sources` are parallel Tavily / Firecrawl candidates and are not automatically used to verify `content`.
-- `fetch` tries Tavily first and uses Firecrawl only as a fallback when Tavily returns no content.
+- `fetch` tries Tavily first, then Jina with `JINA_API_KEY`, then Zhipu Coding Plan MCP Reader, then Firecrawl.
 - `map` currently uses Tavily only.
 - `exa-search` and `exa-similar` use Exa only.
 - `context7-library` and `context7-docs` use Context7 only.
 - `anysearch-domains`, `anysearch-search`, `anysearch-extract`, and `anysearch-batch` use AnySearch only. Treat results as acceptance evidence until the target vertical domain is reviewed.
 - `zhipu-search` uses Zhipu only.
-- Zhipu support currently corresponds to the official Zhipu Web Search API route, using `ZHIPU_API_URL` plus `ZHIPU_SEARCH_ENGINE`; it is not Zhipu Chat Completions `tools=[web_search]`, not Search Agent, and not the MCP Server.
+- `zhipu-search` corresponds to the official Zhipu Web Search API route, using `ZHIPU_API_URL` plus `ZHIPU_SEARCH_ENGINE`; it is not Zhipu Chat Completions `tools=[web_search]`, not Search Agent, and not the MCP Server.
 - `ZHIPU_SEARCH_ENGINE` defaults to `search_std`. Official Web Search API service values include `search_std`, `search_pro`, `search_pro_sogou`, and `search_pro_quark`; keep custom values possible because official services may change.
 - `TAVILY_API_URL` only affects Tavily REST calls and does not proxy Zhipu. Zhipu defaults to `https://open.bigmodel.cn/api` unless `ZHIPU_API_URL` is set.
-- `doctor` tests configured main-search providers, Exa, Tavily, Zhipu, and Context7 connectivity. Firecrawl status currently means the key is configured, not that a live Firecrawl request succeeded.
+- `doctor` tests configured main-search providers, Exa, Tavily, Jina, Zhipu Web Search API, Zhipu Coding Plan MCP, and Context7 connectivity. Firecrawl status currently means the key is configured, not that a live Firecrawl request succeeded.
 
 ## Evidence Files
 
@@ -203,6 +205,8 @@ smart-search search "Iran Hormuz latest military talks" --extra-sources 3 --time
 - The setup wizard prints beginner filling examples for official-service and relay/pooled-endpoint minimum profiles. Keep that guidance on stderr so stdout remains parseable JSON/Markdown/content output.
 - Use `smart-search setup --lang en` for an English wizard and `smart-search setup --advanced` only when low-level config keys must be shown one by one.
 - Use `smart-search setup --non-interactive --zhipu-api-url "https://open.bigmodel.cn/api" --zhipu-search-engine "search_std"` to save Zhipu Web Search API endpoint and search service without prompts.
+- Use `smart-search setup --non-interactive --jina-key "key"` to let Jina satisfy `web_fetch`; `JINA_RESPOND_WITH=readerlm-v2` also requires `JINA_API_KEY`.
+- Use `smart-search setup --non-interactive --zhipu-mcp-key "key"` only when the user explicitly wants Coding Plan Remote MCP quota.
 - Use `smart-search setup --non-interactive --openai-compatible-stream true` only when an OpenAI-compatible relay benefits from SSE streaming for long requests. Default remains false.
 - Use `smart-search setup --non-interactive --anysearch-api-url "https://api.anysearch.com/mcp" --anysearch-key "key"` only for experimental AnySearch acceptance; do not add it to the normal minimum-profile setup.
 - Interactive setup asks for Zhipu API key, API URL, and search service when optional `web_search` reinforcement selects Zhipu.

--- a/skills/smart-search-cli/SKILL.md
+++ b/skills/smart-search-cli/SKILL.md
@@ -137,7 +137,7 @@ Research provider advantage routing:
 - Context7: library/API/framework docs resolution and docs retrieval.
 - Exa: official domains, papers, product/company pages, date/domain-filtered low-noise discovery, and adjacent-source discovery.
 - Zhipu REST: Chinese, domestic, current, policy, and announcement searches.
-- Zhipu MCP: separate Coding Plan quota route through `webSearchPrime` and `webReader`.
+- Zhipu MCP: separate Coding Plan quota route through `web_search_prime` and `webReader`.
 - Tavily: broad source discovery and site map.
 - Jina: known public URL, PDF, and arXiv clean extraction; ReaderLM-v2 requires `JINA_API_KEY`.
 - Firecrawl: robust fetch fallback, JS-heavy/dynamic pages, browser-like extraction, OCR/PDF/structured extraction.
@@ -172,7 +172,7 @@ smart-search deep "https://example.com/source" --format json
 - xAI Responses is the default main answer route for Grok/xAI. In `fallback=auto`, a failed xAI Responses main route can fall back to OpenAI-compatible only when the OpenAI-compatible provider is separately configured.
 - Docs/API/library routing should prefer Context7 first. Exa is for official-domain or low-noise supplemental discovery, not the default docs answer route.
 - Zhipu Web Search API is a general web-search reinforcement and same-capability fallback for Chinese, domestic, current, or domain-filtered source discovery.
-- Zhipu Coding Plan Remote MCP is a separate route: `webSearchPrime` maps to `web_search`, `webReader` maps to `web_fetch`, and zread tools map to explicit repo/docs discovery commands. Do not mix it into the existing `/paas/v4/web_search` REST provider.
+- Zhipu Coding Plan Remote MCP is a separate route: `web_search_prime` maps to `web_search`, `webReader` maps to `web_fetch`, and zread tools map to explicit repo/docs discovery commands. Do not mix it into the existing `/paas/v4/web_search` REST provider.
 - `search` calls Tavily and/or Firecrawl only when `--extra-sources N` is greater than 0.
 - With both Tavily and Firecrawl configured, `search --extra-sources N` splits extra sources between them, with Tavily receiving about 60% and Firecrawl the rest.
 - Search JSON separates `primary_sources`, `extra_sources`, and backward-compatible merged `sources`.

--- a/skills/smart-search-cli/SKILL.md
+++ b/skills/smart-search-cli/SKILL.md
@@ -26,11 +26,12 @@ Use the local `smart-search` command as the default execution layer for web rese
 15. Use `smart-search map` when a documentation site or domain structure matters.
 16. Use `smart-search model current` only to inspect explicit provider models. To change models, use `smart-search config set XAI_MODEL ...` or `smart-search config set OPENAI_COMPATIBLE_MODEL ...`.
 17. For current-news, policy, finance, health, or other high-risk facts, do not answer from broad `search.content` alone. Select the second source by intent: Zhipu for Chinese/current/domestic, Context7 for docs/API, Exa for official/trusted domains or papers, then `fetch` key pages and summarize only what fetched text supports.
-18. Preserve command lines and source URLs in your answer. Prefer citing fetched pages or `primary_sources`; treat `extra_sources` as follow-up candidates, not verified evidence for generated claims.
+18. Use `smart-search research "question" --format json` when the user wants the CLI to run live Deep Research end to end instead of only planning. It executes plan -> discover -> fetch/read -> gap check -> evidence-only synthesis.
+19. Preserve command lines and source URLs in your answer. Prefer citing fetched pages or `primary_sources`; treat `extra_sources` as follow-up candidates, not verified evidence for generated claims.
 
 ## Deep Research Mode
 
-Use Deep Research Mode when the user asks for `深度搜索`, `深度调研`, `深入搜索`, `deep search`, `deep research`, multi-source verification, cross-checking, serious review, or selection/comparison research. This is a capability-based orchestration workflow: the AI agent calls `smart-search deep "question" --format json` to get an offline plan, then composes existing `smart-search` CLI building blocks, the CLI executes those later commands, and JSON/Markdown files provide reproducible evidence. `smart-search deep` is a public planner entrypoint, not an executor; it does not call providers, run `doctor`, or fetch pages by default. It does not change default `smart-search search`, and it does not depend on an MCP session.
+Use Deep Research Mode when the user asks for `深度搜索`, `深度调研`, `深入搜索`, `deep search`, `deep research`, multi-source verification, cross-checking, serious review, or selection/comparison research. This is a capability-based orchestration workflow. The offline route calls `smart-search deep "question" --format json` to get a plan, then composes existing `smart-search` CLI building blocks. The live executor route calls `smart-search research "question" --format json` and lets the CLI execute plan -> discover -> fetch/read -> gap check -> evidence-only synthesis. `smart-search deep` is a public planner entrypoint, not an executor; it does not call providers, run `doctor`, or fetch pages by default. `smart-search research` is the public live executor entrypoint. This does not change default `smart-search search`, and it does not depend on an MCP session.
 
 Do not select a fixed topic recipe. Market, product, technical docs, news, policy, claim-checking, and URL-first prompts are examples of user language, not schema modes. Decide from intent dimensions and capability needs.
 
@@ -122,6 +123,27 @@ Default Deep Research orchestration:
 7. Run `gap_check`: if an important claim lacks fetched evidence, fetch another source or mark the claim/source as unverified.
 
 Default evidence policy is `fetch_before_claim`: key claims in the final answer must be supported by fetched page text. Treat `primary_sources` and `extra_sources` as discovery candidates until the relevant URL has been fetched. The final answer should include fetched evidence, unverified candidate sources, and key commands used.
+
+Live Deep Research executor:
+
+- `smart-search research QUERY [--budget quick|standard|deep] [--evidence-dir PATH] [--fallback auto|off] [--format json|markdown|content] [--output PATH]` runs the staged workflow directly.
+- Default `--fallback auto` permits same-capability fallback inside selected routes. Use `--fallback off` only for debugging or deterministic provider checks.
+- Research output includes `final_answer`, `citations`, `evidence_items`, `gap_check`, `provider_attempts`, `fallback_used`, `degraded`, `route_policy_version`, and `evidence_dir`.
+- The synthesis is evidence-only. It may cite fetched/read evidence, but it must not cite unfetched discovery candidates as proof.
+- If providers are exhausted or evidence cannot close, return the degraded gaps rather than inventing missing claims.
+
+Research provider advantage routing:
+
+- Context7: library/API/framework docs resolution and docs retrieval.
+- Exa: official domains, papers, product/company pages, date/domain-filtered low-noise discovery, and adjacent-source discovery.
+- Zhipu REST: Chinese, domestic, current, policy, and announcement searches.
+- Zhipu MCP: separate Coding Plan quota route through `webSearchPrime` and `webReader`.
+- Tavily: broad source discovery and site map.
+- Jina: known public URL, PDF, and arXiv clean extraction; ReaderLM-v2 requires `JINA_API_KEY`.
+- Firecrawl: robust fetch fallback, JS-heavy/dynamic pages, browser-like extraction, OCR/PDF/structured extraction.
+- AnySearch: explicit vertical intent only, such as CVE, finance, legal, academic, and repository/codebase search.
+
+Safe research overrides are `SMART_SEARCH_RESEARCH_PREFERRED_PROVIDERS` and `SMART_SEARCH_RESEARCH_DISABLED_PROVIDERS`. They may reorder or disable providers only within capabilities the provider already supports; they must not move a provider across capability boundaries.
 
 Deep Research smoke matrix for workflow maintenance is mock-full plus live-limited. Mock-full coverage should include trigger phrases, normal search requests that should not trigger Deep Research, required `research_plan` fields, allowed tool whitelist, `fetch_before_claim`, evidence output paths, capability boundaries, `intent_signals`, `capability_plan`, `gap_check`, simple current prompts such as `深度搜索一下最近的比特币行情`, docs/API prompts, claim-verification prompts, user-provided URL fetch-first flows, missing-provider failure guidance, and the rule that fixed topic recipe ids are not required schema. Live-limited coverage should run `doctor`, one broad `search`, one `exa-search`, and one `fetch` only when real keys are available and the user expects live checks.
 
@@ -234,6 +256,8 @@ smart-search anysearch-extract "https://example.com/source" --format json
 smart-search anysearch-batch "AAPL" "RAG papers" --max-results 2 --format json
 smart-search fetch "https://example.com" --format markdown --output page.md
 smart-search map "https://docs.example.com" --instructions "Find API reference pages" --max-depth 1 --max-breadth 20 --limit 50 --format json
+smart-search research "OpenAI Responses API web_search vs Chat Completions search" --budget deep --fallback auto --format json
+smart-search rs "https://example.com/source" --fallback off --format markdown
 smart-search setup
 smart-search setup --lang en
 smart-search setup --advanced
@@ -282,6 +306,7 @@ Short aliases are supported for interactive use:
 smart-search --v
 smart-search s "query" --format json
 smart-search s "nba战报" --format content
+smart-search rs "query" --format json
 smart-search f "https://example.com" --format markdown
 smart-search exa "OpenAI Responses API documentation" --format json
 smart-search z "today China AI news" --format json

--- a/skills/smart-search-cli/references/cli-contract.md
+++ b/skills/smart-search-cli/references/cli-contract.md
@@ -21,6 +21,11 @@
 - `smart-search exa-search QUERY [--num-results N] [--search-type neural|keyword|auto] [--include-text] [--include-highlights] [--start-published-date YYYY-MM-DD] [--include-domains DOMAIN...] [--exclude-domains DOMAIN...] [--category NAME] [--format json|markdown|content] [--output PATH]`
 - `smart-search exa-similar URL [--num-results N] [--format json|markdown|content] [--output PATH]`
 - `smart-search zhipu-search QUERY [--count N] [--search-engine NAME] [--search-recency-filter VALUE] [--search-domain-filter DOMAIN] [--content-size medium|high] [--format json|markdown|content] [--output PATH]`
+- `smart-search zhipu-mcp-search QUERY [--count N] [--format json|markdown|content] [--output PATH]`
+- `smart-search zhipu-mcp-reader URL [--format json|markdown|content] [--output PATH]`
+- `smart-search zhipu-mcp-search-doc REPO QUERY [--max-results N] [--format json|markdown|content] [--output PATH]`
+- `smart-search zhipu-mcp-repo-structure REPO [--ref REF] [--format json|markdown|content] [--output PATH]`
+- `smart-search zhipu-mcp-read-file REPO PATH [--ref REF] [--format json|markdown|content] [--output PATH]`
 - `smart-search anysearch-domains [DOMAIN] [--format json|markdown|content] [--output PATH]`
 - `smart-search anysearch-search QUERY [--domain DOMAIN] [--sub-domain SUB_DOMAIN] [--max-results N] [--format json|markdown|content] [--output PATH]`
 - `smart-search anysearch-extract URL [--max-length N] [--format json|markdown|content] [--output PATH]`
@@ -31,7 +36,7 @@
 - `smart-search map URL [--instructions TEXT] [--max-depth N] [--max-breadth N] [--limit N] [--timeout SECONDS] [--format json|markdown|content] [--output PATH]`
 - `smart-search doctor [--format json|markdown|content] [--output PATH]`
 - `smart-search diagnose openai-compatible [--timeout SECONDS] [--format json|markdown] [--output PATH]`
-- `smart-search setup [--lang zh|en] [--advanced] [--non-interactive] [--skip-skills] [--install-skills CSV] [--skills-root PATH] [--xai-api-url URL] [--xai-api-key KEY] [--xai-model ID] [--xai-tools-explicit CSV] [--openai-compatible-api-url URL] [--openai-compatible-api-key KEY] [--openai-compatible-model ID] [--openai-compatible-stream true|false] [--validation-level fast|balanced|strict] [--fallback-mode auto|off] [--minimum-profile standard|off] [--exa-key KEY] [--context7-key KEY] [--zhipu-key KEY] [--zhipu-api-url URL] [--zhipu-search-engine ENGINE] [--tavily-api-url URL] [--tavily-key KEY] [--firecrawl-api-url URL] [--firecrawl-key KEY] [--anysearch-api-url URL] [--anysearch-key KEY] [--anysearch-timeout SECONDS] [--format json|markdown|content] [--output PATH]`
+- `smart-search setup [--lang zh|en] [--advanced] [--non-interactive] [--skip-skills] [--install-skills CSV] [--skills-root PATH] [--xai-api-url URL] [--xai-api-key KEY] [--xai-model ID] [--xai-tools-explicit CSV] [--openai-compatible-api-url URL] [--openai-compatible-api-key KEY] [--openai-compatible-model ID] [--openai-compatible-stream true|false] [--validation-level fast|balanced|strict] [--fallback-mode auto|off] [--minimum-profile standard|off] [--exa-key KEY] [--context7-key KEY] [--zhipu-key KEY] [--zhipu-api-url URL] [--zhipu-search-engine ENGINE] [--zhipu-mcp-key KEY] [--zhipu-mcp-search-api-url URL] [--zhipu-mcp-reader-api-url URL] [--zhipu-mcp-zread-api-url URL] [--zhipu-mcp-timeout SECONDS] [--jina-key KEY] [--jina-reader-api-url URL] [--jina-respond-with MODE] [--jina-timeout SECONDS] [--tavily-api-url URL] [--tavily-key KEY] [--firecrawl-api-url URL] [--firecrawl-key KEY] [--anysearch-api-url URL] [--anysearch-key KEY] [--anysearch-timeout SECONDS] [--format json|markdown|content] [--output PATH]`
 - `smart-search config path [--format json|markdown|content] [--output PATH]`
 - `smart-search config list [--format json|markdown|content] [--output PATH]`
 - `smart-search config set KEY VALUE [--format json|markdown|content] [--output PATH]`
@@ -55,6 +60,11 @@ Top-level aliases must normalize to the same service behavior as their full comm
 | `exa-search` | `exa`, `x` |
 | `exa-similar` | `xs` |
 | `zhipu-search` | `z`, `zp` |
+| `zhipu-mcp-search` | `zmcp-search` |
+| `zhipu-mcp-reader` | `zmcp-reader` |
+| `zhipu-mcp-search-doc` | `zmcp-doc` |
+| `zhipu-mcp-repo-structure` | `zmcp-tree` |
+| `zhipu-mcp-read-file` | `zmcp-file` |
 | `anysearch-domains` | `as-domains` |
 | `anysearch-search` | `as-search`, `as` |
 | `anysearch-extract` | `as-extract` |
@@ -104,7 +114,7 @@ Exa domain filters:
 - This normalization is intentional for Windows PowerShell, where an unquoted comma expression can be forwarded through `.ps1` wrappers as a space-separated value.
 - `source_warning`: non-empty when extra source candidates were appended.
 
-Fetch output includes `ok`, `url`, `provider`, `content`, and `elapsed_ms`.
+Fetch output includes `ok`, `url`, `provider`, `content`, `provider_attempts`, `fallback_used`, and `elapsed_ms`.
 
 Zhipu Web Search API setup:
 
@@ -117,6 +127,25 @@ Zhipu Web Search API setup:
 - `zhipu-search` corresponds to Zhipu Web Search API, not Zhipu Chat Completions `tools=[web_search]`, not Search Agent, and not the MCP Server.
 - `TAVILY_API_URL` only affects Tavily and does not proxy Zhipu.
 - `TAVILY_TIMEOUT_SECONDS` controls the Tavily `doctor` connectivity timeout. It defaults to `30` so slower pooled/community endpoints are not incorrectly marked unhealthy by the diagnostic check.
+
+Zhipu Coding Plan Remote MCP setup:
+
+- `ZHIPU_MCP_API_KEY` configures the Coding Plan MCP auth token and must be sent as `Authorization: Bearer ...`; it must never be logged unmasked.
+- `ZHIPU_MCP_SEARCH_API_URL` defaults to `https://open.bigmodel.cn/api/mcp/web_search_prime/mcp` and calls `webSearchPrime` for `web_search`.
+- `ZHIPU_MCP_READER_API_URL` defaults to `https://open.bigmodel.cn/api/mcp/web_reader/mcp` and calls `webReader` for `web_fetch`.
+- `ZHIPU_MCP_ZREAD_API_URL` defaults to `https://open.bigmodel.cn/api/mcp/zread/mcp` and calls `search_doc`, `get_repo_structure`, and `read_file` through explicit repo/docs commands.
+- Zhipu Coding Plan MCP must be implemented as a separate Remote MCP-over-HTTP provider layer. Do not route it through the existing `/paas/v4/web_search` Zhipu REST provider.
+- Provider failures must appear in `provider_attempts` and fallback must remain same-capability.
+- `doctor` should report configured/not-configured, auth, rate-limit, provider, timeout, and network status without exposing the MCP token.
+
+Jina Reader setup:
+
+- `JINA_READER_API_URL` defaults to `https://r.jina.ai`.
+- `JINA_API_KEY` is required before Jina satisfies `SMART_SEARCH_MINIMUM_PROFILE=standard`.
+- Anonymous Jina Reader calls may be used only as explicit/experimental degraded fetch behavior; they must not make standard setup pass.
+- `JINA_RESPOND_WITH=readerlm-v2` requires `JINA_API_KEY` and should report a configuration error without a network request when the key is missing.
+- Jina Reader is `web_fetch` only, not `web_search`.
+- Jina 401/403, 422, 429, timeout, network errors, and low-quality challenge pages such as `Title: Just a moment...` must be reported as failed provider attempts and allow same-capability fallback.
 
 OpenAI-compatible streaming:
 
@@ -142,6 +171,8 @@ Exa HTTP `400` or `422` failures are returned as `ok=false` with `error_type=par
 Exa similar output includes `ok`, `url`, `results`, `total`, and `elapsed_ms` when successful.
 
 Zhipu search output includes `ok`, `query`, `provider`, `search_engine`, `results`, `total`, and `elapsed_ms` when successful.
+
+Zhipu MCP command output includes `ok`, `provider`, `tool`, `elapsed_ms`, and either `content` for reader/file-like tools or `results` plus `total` for search-like tools.
 
 Context7 library output includes `ok`, `query`, `provider`, `results`, `total`, and `elapsed_ms` when successful. Context7 docs output includes `ok`, `library_id`, `query`, `provider`, `results`, `total`, `content`, and `elapsed_ms` when successful.
 
@@ -300,18 +331,21 @@ Agent timeout handling contract:
 - Chat Completions mode must not send xAI `web_search` / `x_search` tools or legacy `search_parameters`; xAI Chat Completions Live Search is deprecated.
 - Standard minimum profile requires `main_search`, `docs_search`, and fetch capability. Missing required capabilities produce a configuration error.
 - Optional experimental `vertical_search` may report AnySearch when `ANYSEARCH_API_KEY` is configured, but it is not part of the `web_search` fallback and is not required by the `standard` minimum profile.
+- Jina satisfies fetch capability only when `JINA_API_KEY` is configured. Anonymous Jina Reader does not satisfy `standard`.
 - Same-capability fallback is allowed; cross-capability fallback is not. Context7 is not used for unrelated broad web queries, and page extraction providers are not used as docs search providers.
 - `main_search`: xAI Responses first for Grok/xAI, then OpenAI-compatible answer fallback when that peer provider is separately configured and `--fallback auto` is active.
-- `web_search`: Zhipu first when routed in, then Tavily / Firecrawl source search when configured.
+- `web_search`: Zhipu Web Search API first when routed in, then Zhipu Coding Plan MCP `webSearchPrime`, then Tavily / Firecrawl source search when configured.
 - `docs_search`: Context7 first for library/API/docs intent, then Exa for official-domain, paper, product-page, trusted-site, or low-noise supplemental discovery.
-- Fetch capability: Tavily first, then Firecrawl.
+- Fetch capability: Tavily first, then Jina Reader with `JINA_API_KEY`, then Zhipu Coding Plan MCP `webReader`, then Firecrawl.
 - `search` calls Tavily and/or Firecrawl only when `--extra-sources` is greater than 0.
 - If both Tavily and Firecrawl are configured, `search --extra-sources N` gives about 60% of extra source slots to Tavily and the remainder to Firecrawl.
 - `extra_sources` are retrieved in parallel and are not automatically used by the primary model to verify its answer.
-- `fetch` tries Tavily first, then Firecrawl as fallback when Tavily returns no content.
+- `fetch` and known-URL `search "https://..."` use the same fetch fallback chain.
+- `fetch` tries Tavily first, then Jina Reader with `JINA_API_KEY`, then Zhipu Coding Plan MCP Reader, then Firecrawl.
 - `map` uses Tavily only.
 - `exa-search` and `exa-similar` use Exa only.
 - `zhipu-search` uses Zhipu only.
+- `zhipu-mcp-search`, `zhipu-mcp-reader`, and `zhipu-mcp-*` zread commands use Zhipu Coding Plan Remote MCP only.
 - `anysearch-domains`, `anysearch-search`, `anysearch-extract`, and `anysearch-batch` use AnySearch only and do not participate in default fallback chains.
 - `context7-library` and `context7-docs` use Context7 only.
 - Runtime config priority is environment variables first, then local config file, then defaults.

--- a/skills/smart-search-cli/references/cli-contract.md
+++ b/skills/smart-search-cli/references/cli-contract.md
@@ -33,6 +33,7 @@
 - `smart-search context7-library NAME [QUERY] [--format json|markdown|content] [--output PATH]`
 - `smart-search context7-docs LIBRARY_ID QUERY [--format json|markdown|content] [--output PATH]`
 - `smart-search deep QUERY [--budget quick|standard|deep] [--evidence-dir PATH] [--format json|markdown|content] [--output PATH]`
+- `smart-search research QUERY [--budget quick|standard|deep] [--evidence-dir PATH] [--fallback auto|off] [--format json|markdown|content] [--output PATH]`
 - `smart-search map URL [--instructions TEXT] [--max-depth N] [--max-breadth N] [--limit N] [--timeout SECONDS] [--format json|markdown|content] [--output PATH]`
 - `smart-search doctor [--format json|markdown|content] [--output PATH]`
 - `smart-search diagnose openai-compatible [--timeout SECONDS] [--format json|markdown] [--output PATH]`
@@ -72,6 +73,7 @@ Top-level aliases must normalize to the same service behavior as their full comm
 | `context7-library` | `c7`, `ctx7` |
 | `context7-docs` | `c7d`, `c7docs`, `ctx7-docs` |
 | `deep` | `dr` |
+| `research` | `rs` |
 | `doctor` | `d` |
 | `diagnose` | `diag` |
 | `setup` | `init` |
@@ -99,7 +101,7 @@ Successful search output includes `ok`, `query`, `primary_api_mode`, `content`, 
 
 `--format markdown` is the human-readable report format. `doctor --format markdown` must render a detailed diagnostic report with overall status, active/default/legacy config paths, log path resolution, file-logging status, masked config values with sources, minimum profile, capability status, main-search provider checks, provider connectivity checks, model metadata, and full long error/message detail instead of falling back to raw JSON. `diagnose openai-compatible --format markdown` must render a short copy-pasteable troubleshooting report with masked config, quick chat check, real search-shape `stream=false` and `stream=true` checks, a plain-language summary, and a next command. Provider list commands such as `exa-search`, `exa-similar`, `zhipu-search`, `anysearch-*`, `context7-library`, and `map` render result lists or a clear no-results message.
 
-`--format content` prints only the `content` field for content-bearing commands such as `search`, `fetch`, and `context7-docs`. Commands without a `content` field, including `doctor`, `smoke`, `config`, and `model`, must print a compact non-empty text summary rather than an empty stdout.
+`--format content` prints only the `content` field for content-bearing commands such as `search`, `fetch`, `context7-docs`, and `research`. Commands without a `content` field, including `doctor`, `smoke`, `config`, and `model`, must print a compact non-empty text summary rather than an empty stdout.
 
 Source provenance fields:
 
@@ -178,7 +180,9 @@ Context7 library output includes `ok`, `query`, `provider`, `results`, `total`, 
 
 Map output includes `ok`, `base_url`, `results`, `response_time`, `url`, and `elapsed_ms` when successful.
 
-Deep planner output includes `ok`, `mode`, `query_mode`, `question`, `trigger_source`, `difficulty`, `intent_signals`, `decomposition`, `capability_plan`, `evidence_policy`, `preflight`, `steps`, `gap_check`, `final_answer_policy`, `usage_boundary`, `allowed_tools`, `evidence_dir`, and `elapsed_ms`. `smart-search deep` is offline by default: `preflight.executed_by_deep_command=false`, no provider calls are made, and live research only happens when an AI agent or user executes `steps[].command`.
+Deep planner output includes `ok`, `mode`, `query_mode`, `question`, `trigger_source`, `difficulty`, `intent_signals`, `decomposition`, `capability_plan`, `evidence_policy`, `preflight`, `steps`, `gap_check`, `final_answer_policy`, `usage_boundary`, `allowed_tools`, `evidence_dir`, and `elapsed_ms`. `smart-search deep` is offline by default: `preflight.executed_by_deep_command=false`, no provider calls are made, and live research only happens when an AI agent or user executes `steps[].command` or calls `smart-search research`.
+
+Research executor output includes `ok`, `mode=deep_research_execution`, `query_mode=research`, `question`, `budget`, `research_plan`, `routing_decision`, `stage_results`, `discovery_sources`, `final_answer`, `content`, `citations`, `evidence_items`, `gap_check`, `provider_attempts`, `providers_used`, `fallback_used`, `degraded`, `route_policy_version`, `evidence_dir`, `minimum_profile_ok`, `capability_status`, and `elapsed_ms`. Citations must come only from fetched/read `evidence_items`; discovery sources are candidates until fetched. If evidence cannot close, `research` returns degraded gaps instead of unsupported claims.
 
 Diagnostic output masks keys, reports `config_file` / `config_dir` / `config_dir_source` / `default_config_file` / Windows legacy config metadata / `config_dir_override_value` / `config_dir_override_matches_default` / `log_dir_config_value` / `resolved_log_dir` / `file_logging_enabled` / `config_sources` / `primary_api_mode` / `primary_api_mode_source` / provider timeout values / `capability_status` / `minimum_profile_ok`, and includes `main_search_connection_tests` plus connection test objects for Exa, Tavily, Zhipu, Context7, and Firecrawl. `primary_connection_test` remains as a backward-compatible alias for the first configured main provider check. OpenAI-compatible provider health must be validated through `/chat/completions`; `/models` is supplementary metadata and must not be the health gate. Firecrawl currently reports whether `FIRECRAWL_API_KEY` is configured; it is not a live Firecrawl request.
 
@@ -188,7 +192,7 @@ Smoke output includes `ok`, `mode`, `failed_cases`, `cases`, `provider_attempts`
 
 ## Deep Research Skill Contract
 
-Deep Research is an optional capability orchestration workflow for prompts such as `深度搜索`, `深度调研`, `深入搜索`, `deep search`, `deep research`, multi-source verification, cross-checking, serious review, and selection/comparison research. `smart-search deep` is the public offline planner command for this workflow. It must not change default `smart-search search` behavior and must not execute live providers by default. The AI agent reads the generated plan, composes existing CLI commands, and lets the CLI perform execution and write JSON/Markdown evidence.
+Deep Research is an optional capability orchestration workflow for prompts such as `深度搜索`, `深度调研`, `深入搜索`, `deep search`, `deep research`, multi-source verification, cross-checking, serious review, and selection/comparison research. `smart-search deep` is the public offline planner command for this workflow. `smart-search research` is the public live executor command. It must not change default `smart-search search` behavior. `deep` must not execute live providers by default. `research` executes the staged workflow and writes JSON/Markdown evidence.
 
 Deep Research must not require fixed topic recipe ids such as `current_market_research`, `product_comparison_research`, `technical_docs_research`, `news_or_policy_research`, `claim_verification_research`, or `url_first_research`. Those phrases may appear as prompt examples, but they are not schema modes or routing enums.
 
@@ -234,13 +238,34 @@ Default Deep Research orchestration:
 
 `fetch_before_claim` means key claims must be backed by fetched page content. `primary_sources` and `extra_sources` are discovery candidates until fetched. Final answers should include fetched evidence, unverified candidate sources, and key commands used.
 
+When the user wants the CLI to execute the live workflow directly, call:
+
+```powershell
+smart-search research "question" --budget deep --fallback auto --format json --output C:\tmp\smart-search-evidence\research.json
+```
+
+`research --fallback auto` permits same-capability fallback inside selected routes. `research --fallback off` tries only the first selected provider in each capability route and is for debugging or provider comparison. Dynamic routing may reorder providers only inside the same capability. Every attempt must record capability, provider, status, error type, latency, and result count.
+
+Research provider advantage routing:
+
+- Context7 first for library/API/framework docs and docs retrieval.
+- Exa for official domains, papers, product/company pages, date/domain-filtered low-noise discovery, and adjacent-source discovery.
+- Zhipu REST for Chinese, domestic, current, policy, and announcement searches.
+- Zhipu MCP as a separate Coding Plan quota route through `webSearchPrime` and `webReader`; do not mix it into `/paas/v4/web_search`.
+- Tavily for broad source discovery and site maps.
+- Jina for known public URL, PDF, and arXiv clean extraction; ReaderLM-v2 requires `JINA_API_KEY`.
+- Firecrawl for robust fetch fallback, JS-heavy/dynamic/browser-like extraction, OCR/PDF/structured extraction.
+- AnySearch only when vertical intent is clear, such as CVE, finance, legal, academic, and repository/codebase search.
+
+Safe research overrides are `SMART_SEARCH_RESEARCH_PREFERRED_PROVIDERS` and `SMART_SEARCH_RESEARCH_DISABLED_PROVIDERS`. They may reorder or disable providers only inside capabilities the provider already supports; they must not move a provider across capability boundaries.
+
 Planner closeout lessons:
 
 - Budget limits must not break evidence policy. Even `--budget quick` plans must retain at least one `fetch` step when claim-level conclusions are expected, and retained steps must keep valid `subquestion_id` links.
 - `steps[].command` and `steps[].output_path` are one contract. The `--output` path embedded in the executable command must match `output_path`; otherwise the AI agent cannot reliably find saved evidence.
 - Prefer PowerShell-safe quoted commands in generated plans because Windows users often copy planned steps directly from Markdown or JSON output.
 
-Deep Research smoke coverage is mock-full plus live-limited. Mock-full coverage should cover trigger phrases, normal search requests that should not trigger Deep Research, required `research_plan` fields, allowed tool whitelist, `fetch_before_claim`, evidence paths, capability boundaries, `intent_signals`, `capability_plan`, `gap_check`, simple current prompts such as `深度搜索一下最近的比特币行情`, docs/API prompts, claim-verification prompts, user-provided URL fetch-first flows, missing-provider failure guidance, and the rule that fixed topic recipe ids are not required schema. Live-limited coverage should run `doctor`, one broad `search`, one `exa-search`, and one `fetch` when real keys are available and live checks are expected. If a smoke issue is found, fix the affected docs/code/tests and rerun the affected smoke until it passes or is proven to be an external provider blocker.
+Deep Research smoke coverage is mock-full plus live-limited. Mock-full coverage should cover trigger phrases, normal search requests that should not trigger Deep Research, required `research_plan` fields, allowed tool whitelist, `fetch_before_claim`, evidence paths, capability boundaries, `intent_signals`, `capability_plan`, `gap_check`, simple current prompts such as `深度搜索一下最近的比特币行情`, docs/API prompts, claim-verification prompts, user-provided URL fetch-first flows, missing-provider failure guidance, research provider advantage routing, same-capability research fallback, and the rule that fixed topic recipe ids are not required schema. Live-limited coverage should run `doctor`, one broad `search`, one `exa-search`, and one `fetch` when real keys are available and live checks are expected; add one small `research` smoke when configured keys make it stable. If a smoke issue is found, fix the affected docs/code/tests and rerun the affected smoke until it passes or is proven to be an external provider blocker.
 
 Setup and config output should include `ok` and `config_file`. Saved API keys must be masked in command output.
 
@@ -342,6 +367,7 @@ Agent timeout handling contract:
 - `extra_sources` are retrieved in parallel and are not automatically used by the primary model to verify its answer.
 - `fetch` and known-URL `search "https://..."` use the same fetch fallback chain.
 - `fetch` tries Tavily first, then Jina Reader with `JINA_API_KEY`, then Zhipu Coding Plan MCP Reader, then Firecrawl.
+- `research` uses capability-first plus provider-advantage routing. Fallback remains same-capability only; low-quality fetches, challenge pages, empty content, auth/rate/timeout/provider errors, and runtime errors are failed attempts that may trigger same-capability fallback.
 - `map` uses Tavily only.
 - `exa-search` and `exa-similar` use Exa only.
 - `zhipu-search` uses Zhipu only.

--- a/skills/smart-search-cli/references/cli-contract.md
+++ b/skills/smart-search-cli/references/cli-contract.md
@@ -137,6 +137,7 @@ Zhipu Coding Plan Remote MCP setup:
 - `ZHIPU_MCP_READER_API_URL` defaults to `https://open.bigmodel.cn/api/mcp/web_reader/mcp` and calls `webReader` for `web_fetch`.
 - `ZHIPU_MCP_ZREAD_API_URL` defaults to `https://open.bigmodel.cn/api/mcp/zread/mcp` and calls `search_doc`, `get_repo_structure`, and `read_file` through explicit repo/docs commands.
 - Zhipu Coding Plan MCP must be implemented as a separate Remote MCP-over-HTTP provider layer. Do not route it through the existing `/paas/v4/web_search` Zhipu REST provider.
+- A normal Zhipu Web Search API key is not sufficient evidence of Coding Plan entitlement. If `ZHIPU_MCP_API_KEY` is missing or returns auth/provider errors, MCP providers are skipped or fall through within the same capability; zread remains explicit and does not affect the standard minimum profile.
 - Provider failures must appear in `provider_attempts` and fallback must remain same-capability.
 - `doctor` should report configured/not-configured, auth, rate-limit, provider, timeout, and network status without exposing the MCP token.
 

--- a/skills/smart-search-cli/references/cli-contract.md
+++ b/skills/smart-search-cli/references/cli-contract.md
@@ -133,7 +133,7 @@ Zhipu Web Search API setup:
 Zhipu Coding Plan Remote MCP setup:
 
 - `ZHIPU_MCP_API_KEY` configures the Coding Plan MCP auth token and must be sent as `Authorization: Bearer ...`; it must never be logged unmasked.
-- `ZHIPU_MCP_SEARCH_API_URL` defaults to `https://open.bigmodel.cn/api/mcp/web_search_prime/mcp` and calls `webSearchPrime` for `web_search`.
+- `ZHIPU_MCP_SEARCH_API_URL` defaults to `https://open.bigmodel.cn/api/mcp/web_search_prime/mcp` and calls `web_search_prime` for `web_search`.
 - `ZHIPU_MCP_READER_API_URL` defaults to `https://open.bigmodel.cn/api/mcp/web_reader/mcp` and calls `webReader` for `web_fetch`.
 - `ZHIPU_MCP_ZREAD_API_URL` defaults to `https://open.bigmodel.cn/api/mcp/zread/mcp` and calls `search_doc`, `get_repo_structure`, and `read_file` through explicit repo/docs commands.
 - Zhipu Coding Plan MCP must be implemented as a separate Remote MCP-over-HTTP provider layer. Do not route it through the existing `/paas/v4/web_search` Zhipu REST provider.
@@ -251,7 +251,7 @@ Research provider advantage routing:
 - Context7 first for library/API/framework docs and docs retrieval.
 - Exa for official domains, papers, product/company pages, date/domain-filtered low-noise discovery, and adjacent-source discovery.
 - Zhipu REST for Chinese, domestic, current, policy, and announcement searches.
-- Zhipu MCP as a separate Coding Plan quota route through `webSearchPrime` and `webReader`; do not mix it into `/paas/v4/web_search`.
+- Zhipu MCP as a separate Coding Plan quota route through `web_search_prime` and `webReader`; do not mix it into `/paas/v4/web_search`.
 - Tavily for broad source discovery and site maps.
 - Jina for known public URL, PDF, and arXiv clean extraction; ReaderLM-v2 requires `JINA_API_KEY`.
 - Firecrawl for robust fetch fallback, JS-heavy/dynamic/browser-like extraction, OCR/PDF/structured extraction.
@@ -359,7 +359,7 @@ Agent timeout handling contract:
 - Jina satisfies fetch capability only when `JINA_API_KEY` is configured. Anonymous Jina Reader does not satisfy `standard`.
 - Same-capability fallback is allowed; cross-capability fallback is not. Context7 is not used for unrelated broad web queries, and page extraction providers are not used as docs search providers.
 - `main_search`: xAI Responses first for Grok/xAI, then OpenAI-compatible answer fallback when that peer provider is separately configured and `--fallback auto` is active.
-- `web_search`: Zhipu Web Search API first when routed in, then Zhipu Coding Plan MCP `webSearchPrime`, then Tavily / Firecrawl source search when configured.
+- `web_search`: Zhipu Web Search API first when routed in, then Zhipu Coding Plan MCP `web_search_prime`, then Tavily / Firecrawl source search when configured.
 - `docs_search`: Context7 first for library/API/docs intent, then Exa for official-domain, paper, product-page, trusted-site, or low-noise supplemental discovery.
 - Fetch capability: Tavily first, then Jina Reader with `JINA_API_KEY`, then Zhipu Coding Plan MCP `webReader`, then Firecrawl.
 - `search` calls Tavily and/or Firecrawl only when `--extra-sources` is greater than 0.

--- a/src/smart_search/assets/skills/smart-search-cli/SKILL.md
+++ b/src/smart_search/assets/skills/smart-search-cli/SKILL.md
@@ -145,24 +145,26 @@ smart-search deep "https://example.com/source" --format json
 - Chat Completions mode must not send xAI `web_search` / `x_search` tools or legacy `search_parameters`; xAI Chat Completions Live Search is deprecated.
 - The standard minimum profile requires one configured provider in each of `main_search`, `docs_search`, and fetch capability. Missing required capabilities should be treated as a hard configuration failure.
 - AnySearch is reported only as optional experimental `vertical_search`; it is not part of the `web_search` fallback and is not required by the `standard` minimum profile.
+- Jina Reader is `web_fetch` only, not a general search provider. `JINA_API_KEY` is required before Jina satisfies the standard minimum profile; anonymous `r.jina.ai` is explicit/experimental fetch behavior.
 - `search` exposes `--validation fast|balanced|strict`, `--fallback auto|off`, and `--providers auto|CSV`. Default validation is `balanced`; fallback only happens within the same capability.
 - xAI Responses is the default main answer route for Grok/xAI. In `fallback=auto`, a failed xAI Responses main route can fall back to OpenAI-compatible only when the OpenAI-compatible provider is separately configured.
 - Docs/API/library routing should prefer Context7 first. Exa is for official-domain or low-noise supplemental discovery, not the default docs answer route.
-- Zhipu is a general web-search reinforcement and same-capability fallback for Chinese, domestic, current, or domain-filtered source discovery.
+- Zhipu Web Search API is a general web-search reinforcement and same-capability fallback for Chinese, domestic, current, or domain-filtered source discovery.
+- Zhipu Coding Plan Remote MCP is a separate route: `webSearchPrime` maps to `web_search`, `webReader` maps to `web_fetch`, and zread tools map to explicit repo/docs discovery commands. Do not mix it into the existing `/paas/v4/web_search` REST provider.
 - `search` calls Tavily and/or Firecrawl only when `--extra-sources N` is greater than 0.
 - With both Tavily and Firecrawl configured, `search --extra-sources N` splits extra sources between them, with Tavily receiving about 60% and Firecrawl the rest.
 - Search JSON separates `primary_sources`, `extra_sources`, and backward-compatible merged `sources`.
 - `primary_sources` are extracted from the primary model answer. `extra_sources` are parallel Tavily / Firecrawl candidates and are not automatically used to verify `content`.
-- `fetch` tries Tavily first and uses Firecrawl only as a fallback when Tavily returns no content.
+- `fetch` tries Tavily first, then Jina with `JINA_API_KEY`, then Zhipu Coding Plan MCP Reader, then Firecrawl.
 - `map` currently uses Tavily only.
 - `exa-search` and `exa-similar` use Exa only.
 - `context7-library` and `context7-docs` use Context7 only.
 - `anysearch-domains`, `anysearch-search`, `anysearch-extract`, and `anysearch-batch` use AnySearch only. Treat results as acceptance evidence until the target vertical domain is reviewed.
 - `zhipu-search` uses Zhipu only.
-- Zhipu support currently corresponds to the official Zhipu Web Search API route, using `ZHIPU_API_URL` plus `ZHIPU_SEARCH_ENGINE`; it is not Zhipu Chat Completions `tools=[web_search]`, not Search Agent, and not the MCP Server.
+- `zhipu-search` corresponds to the official Zhipu Web Search API route, using `ZHIPU_API_URL` plus `ZHIPU_SEARCH_ENGINE`; it is not Zhipu Chat Completions `tools=[web_search]`, not Search Agent, and not the MCP Server.
 - `ZHIPU_SEARCH_ENGINE` defaults to `search_std`. Official Web Search API service values include `search_std`, `search_pro`, `search_pro_sogou`, and `search_pro_quark`; keep custom values possible because official services may change.
 - `TAVILY_API_URL` only affects Tavily REST calls and does not proxy Zhipu. Zhipu defaults to `https://open.bigmodel.cn/api` unless `ZHIPU_API_URL` is set.
-- `doctor` tests configured main-search providers, Exa, Tavily, Zhipu, and Context7 connectivity. Firecrawl status currently means the key is configured, not that a live Firecrawl request succeeded.
+- `doctor` tests configured main-search providers, Exa, Tavily, Jina, Zhipu Web Search API, Zhipu Coding Plan MCP, and Context7 connectivity. Firecrawl status currently means the key is configured, not that a live Firecrawl request succeeded.
 
 ## Evidence Files
 
@@ -203,6 +205,8 @@ smart-search search "Iran Hormuz latest military talks" --extra-sources 3 --time
 - The setup wizard prints beginner filling examples for official-service and relay/pooled-endpoint minimum profiles. Keep that guidance on stderr so stdout remains parseable JSON/Markdown/content output.
 - Use `smart-search setup --lang en` for an English wizard and `smart-search setup --advanced` only when low-level config keys must be shown one by one.
 - Use `smart-search setup --non-interactive --zhipu-api-url "https://open.bigmodel.cn/api" --zhipu-search-engine "search_std"` to save Zhipu Web Search API endpoint and search service without prompts.
+- Use `smart-search setup --non-interactive --jina-key "key"` to let Jina satisfy `web_fetch`; `JINA_RESPOND_WITH=readerlm-v2` also requires `JINA_API_KEY`.
+- Use `smart-search setup --non-interactive --zhipu-mcp-key "key"` only when the user explicitly wants Coding Plan Remote MCP quota.
 - Use `smart-search setup --non-interactive --openai-compatible-stream true` only when an OpenAI-compatible relay benefits from SSE streaming for long requests. Default remains false.
 - Use `smart-search setup --non-interactive --anysearch-api-url "https://api.anysearch.com/mcp" --anysearch-key "key"` only for experimental AnySearch acceptance; do not add it to the normal minimum-profile setup.
 - Interactive setup asks for Zhipu API key, API URL, and search service when optional `web_search` reinforcement selects Zhipu.

--- a/src/smart_search/assets/skills/smart-search-cli/SKILL.md
+++ b/src/smart_search/assets/skills/smart-search-cli/SKILL.md
@@ -137,7 +137,7 @@ Research provider advantage routing:
 - Context7: library/API/framework docs resolution and docs retrieval.
 - Exa: official domains, papers, product/company pages, date/domain-filtered low-noise discovery, and adjacent-source discovery.
 - Zhipu REST: Chinese, domestic, current, policy, and announcement searches.
-- Zhipu MCP: separate Coding Plan quota route through `webSearchPrime` and `webReader`.
+- Zhipu MCP: separate Coding Plan quota route through `web_search_prime` and `webReader`.
 - Tavily: broad source discovery and site map.
 - Jina: known public URL, PDF, and arXiv clean extraction; ReaderLM-v2 requires `JINA_API_KEY`.
 - Firecrawl: robust fetch fallback, JS-heavy/dynamic pages, browser-like extraction, OCR/PDF/structured extraction.
@@ -172,7 +172,7 @@ smart-search deep "https://example.com/source" --format json
 - xAI Responses is the default main answer route for Grok/xAI. In `fallback=auto`, a failed xAI Responses main route can fall back to OpenAI-compatible only when the OpenAI-compatible provider is separately configured.
 - Docs/API/library routing should prefer Context7 first. Exa is for official-domain or low-noise supplemental discovery, not the default docs answer route.
 - Zhipu Web Search API is a general web-search reinforcement and same-capability fallback for Chinese, domestic, current, or domain-filtered source discovery.
-- Zhipu Coding Plan Remote MCP is a separate route: `webSearchPrime` maps to `web_search`, `webReader` maps to `web_fetch`, and zread tools map to explicit repo/docs discovery commands. Do not mix it into the existing `/paas/v4/web_search` REST provider.
+- Zhipu Coding Plan Remote MCP is a separate route: `web_search_prime` maps to `web_search`, `webReader` maps to `web_fetch`, and zread tools map to explicit repo/docs discovery commands. Do not mix it into the existing `/paas/v4/web_search` REST provider.
 - `search` calls Tavily and/or Firecrawl only when `--extra-sources N` is greater than 0.
 - With both Tavily and Firecrawl configured, `search --extra-sources N` splits extra sources between them, with Tavily receiving about 60% and Firecrawl the rest.
 - Search JSON separates `primary_sources`, `extra_sources`, and backward-compatible merged `sources`.

--- a/src/smart_search/assets/skills/smart-search-cli/SKILL.md
+++ b/src/smart_search/assets/skills/smart-search-cli/SKILL.md
@@ -26,11 +26,12 @@ Use the local `smart-search` command as the default execution layer for web rese
 15. Use `smart-search map` when a documentation site or domain structure matters.
 16. Use `smart-search model current` only to inspect explicit provider models. To change models, use `smart-search config set XAI_MODEL ...` or `smart-search config set OPENAI_COMPATIBLE_MODEL ...`.
 17. For current-news, policy, finance, health, or other high-risk facts, do not answer from broad `search.content` alone. Select the second source by intent: Zhipu for Chinese/current/domestic, Context7 for docs/API, Exa for official/trusted domains or papers, then `fetch` key pages and summarize only what fetched text supports.
-18. Preserve command lines and source URLs in your answer. Prefer citing fetched pages or `primary_sources`; treat `extra_sources` as follow-up candidates, not verified evidence for generated claims.
+18. Use `smart-search research "question" --format json` when the user wants the CLI to run live Deep Research end to end instead of only planning. It executes plan -> discover -> fetch/read -> gap check -> evidence-only synthesis.
+19. Preserve command lines and source URLs in your answer. Prefer citing fetched pages or `primary_sources`; treat `extra_sources` as follow-up candidates, not verified evidence for generated claims.
 
 ## Deep Research Mode
 
-Use Deep Research Mode when the user asks for `深度搜索`, `深度调研`, `深入搜索`, `deep search`, `deep research`, multi-source verification, cross-checking, serious review, or selection/comparison research. This is a capability-based orchestration workflow: the AI agent calls `smart-search deep "question" --format json` to get an offline plan, then composes existing `smart-search` CLI building blocks, the CLI executes those later commands, and JSON/Markdown files provide reproducible evidence. `smart-search deep` is a public planner entrypoint, not an executor; it does not call providers, run `doctor`, or fetch pages by default. It does not change default `smart-search search`, and it does not depend on an MCP session.
+Use Deep Research Mode when the user asks for `深度搜索`, `深度调研`, `深入搜索`, `deep search`, `deep research`, multi-source verification, cross-checking, serious review, or selection/comparison research. This is a capability-based orchestration workflow. The offline route calls `smart-search deep "question" --format json` to get a plan, then composes existing `smart-search` CLI building blocks. The live executor route calls `smart-search research "question" --format json` and lets the CLI execute plan -> discover -> fetch/read -> gap check -> evidence-only synthesis. `smart-search deep` is a public planner entrypoint, not an executor; it does not call providers, run `doctor`, or fetch pages by default. `smart-search research` is the public live executor entrypoint. This does not change default `smart-search search`, and it does not depend on an MCP session.
 
 Do not select a fixed topic recipe. Market, product, technical docs, news, policy, claim-checking, and URL-first prompts are examples of user language, not schema modes. Decide from intent dimensions and capability needs.
 
@@ -122,6 +123,27 @@ Default Deep Research orchestration:
 7. Run `gap_check`: if an important claim lacks fetched evidence, fetch another source or mark the claim/source as unverified.
 
 Default evidence policy is `fetch_before_claim`: key claims in the final answer must be supported by fetched page text. Treat `primary_sources` and `extra_sources` as discovery candidates until the relevant URL has been fetched. The final answer should include fetched evidence, unverified candidate sources, and key commands used.
+
+Live Deep Research executor:
+
+- `smart-search research QUERY [--budget quick|standard|deep] [--evidence-dir PATH] [--fallback auto|off] [--format json|markdown|content] [--output PATH]` runs the staged workflow directly.
+- Default `--fallback auto` permits same-capability fallback inside selected routes. Use `--fallback off` only for debugging or deterministic provider checks.
+- Research output includes `final_answer`, `citations`, `evidence_items`, `gap_check`, `provider_attempts`, `fallback_used`, `degraded`, `route_policy_version`, and `evidence_dir`.
+- The synthesis is evidence-only. It may cite fetched/read evidence, but it must not cite unfetched discovery candidates as proof.
+- If providers are exhausted or evidence cannot close, return the degraded gaps rather than inventing missing claims.
+
+Research provider advantage routing:
+
+- Context7: library/API/framework docs resolution and docs retrieval.
+- Exa: official domains, papers, product/company pages, date/domain-filtered low-noise discovery, and adjacent-source discovery.
+- Zhipu REST: Chinese, domestic, current, policy, and announcement searches.
+- Zhipu MCP: separate Coding Plan quota route through `webSearchPrime` and `webReader`.
+- Tavily: broad source discovery and site map.
+- Jina: known public URL, PDF, and arXiv clean extraction; ReaderLM-v2 requires `JINA_API_KEY`.
+- Firecrawl: robust fetch fallback, JS-heavy/dynamic pages, browser-like extraction, OCR/PDF/structured extraction.
+- AnySearch: explicit vertical intent only, such as CVE, finance, legal, academic, and repository/codebase search.
+
+Safe research overrides are `SMART_SEARCH_RESEARCH_PREFERRED_PROVIDERS` and `SMART_SEARCH_RESEARCH_DISABLED_PROVIDERS`. They may reorder or disable providers only within capabilities the provider already supports; they must not move a provider across capability boundaries.
 
 Deep Research smoke matrix for workflow maintenance is mock-full plus live-limited. Mock-full coverage should include trigger phrases, normal search requests that should not trigger Deep Research, required `research_plan` fields, allowed tool whitelist, `fetch_before_claim`, evidence output paths, capability boundaries, `intent_signals`, `capability_plan`, `gap_check`, simple current prompts such as `深度搜索一下最近的比特币行情`, docs/API prompts, claim-verification prompts, user-provided URL fetch-first flows, missing-provider failure guidance, and the rule that fixed topic recipe ids are not required schema. Live-limited coverage should run `doctor`, one broad `search`, one `exa-search`, and one `fetch` only when real keys are available and the user expects live checks.
 
@@ -234,6 +256,8 @@ smart-search anysearch-extract "https://example.com/source" --format json
 smart-search anysearch-batch "AAPL" "RAG papers" --max-results 2 --format json
 smart-search fetch "https://example.com" --format markdown --output page.md
 smart-search map "https://docs.example.com" --instructions "Find API reference pages" --max-depth 1 --max-breadth 20 --limit 50 --format json
+smart-search research "OpenAI Responses API web_search vs Chat Completions search" --budget deep --fallback auto --format json
+smart-search rs "https://example.com/source" --fallback off --format markdown
 smart-search setup
 smart-search setup --lang en
 smart-search setup --advanced
@@ -282,6 +306,7 @@ Short aliases are supported for interactive use:
 smart-search --v
 smart-search s "query" --format json
 smart-search s "nba战报" --format content
+smart-search rs "query" --format json
 smart-search f "https://example.com" --format markdown
 smart-search exa "OpenAI Responses API documentation" --format json
 smart-search z "today China AI news" --format json

--- a/src/smart_search/assets/skills/smart-search-cli/references/cli-contract.md
+++ b/src/smart_search/assets/skills/smart-search-cli/references/cli-contract.md
@@ -21,6 +21,11 @@
 - `smart-search exa-search QUERY [--num-results N] [--search-type neural|keyword|auto] [--include-text] [--include-highlights] [--start-published-date YYYY-MM-DD] [--include-domains DOMAIN...] [--exclude-domains DOMAIN...] [--category NAME] [--format json|markdown|content] [--output PATH]`
 - `smart-search exa-similar URL [--num-results N] [--format json|markdown|content] [--output PATH]`
 - `smart-search zhipu-search QUERY [--count N] [--search-engine NAME] [--search-recency-filter VALUE] [--search-domain-filter DOMAIN] [--content-size medium|high] [--format json|markdown|content] [--output PATH]`
+- `smart-search zhipu-mcp-search QUERY [--count N] [--format json|markdown|content] [--output PATH]`
+- `smart-search zhipu-mcp-reader URL [--format json|markdown|content] [--output PATH]`
+- `smart-search zhipu-mcp-search-doc REPO QUERY [--max-results N] [--format json|markdown|content] [--output PATH]`
+- `smart-search zhipu-mcp-repo-structure REPO [--ref REF] [--format json|markdown|content] [--output PATH]`
+- `smart-search zhipu-mcp-read-file REPO PATH [--ref REF] [--format json|markdown|content] [--output PATH]`
 - `smart-search anysearch-domains [DOMAIN] [--format json|markdown|content] [--output PATH]`
 - `smart-search anysearch-search QUERY [--domain DOMAIN] [--sub-domain SUB_DOMAIN] [--max-results N] [--format json|markdown|content] [--output PATH]`
 - `smart-search anysearch-extract URL [--max-length N] [--format json|markdown|content] [--output PATH]`
@@ -31,7 +36,7 @@
 - `smart-search map URL [--instructions TEXT] [--max-depth N] [--max-breadth N] [--limit N] [--timeout SECONDS] [--format json|markdown|content] [--output PATH]`
 - `smart-search doctor [--format json|markdown|content] [--output PATH]`
 - `smart-search diagnose openai-compatible [--timeout SECONDS] [--format json|markdown] [--output PATH]`
-- `smart-search setup [--lang zh|en] [--advanced] [--non-interactive] [--skip-skills] [--install-skills CSV] [--skills-root PATH] [--xai-api-url URL] [--xai-api-key KEY] [--xai-model ID] [--xai-tools-explicit CSV] [--openai-compatible-api-url URL] [--openai-compatible-api-key KEY] [--openai-compatible-model ID] [--openai-compatible-stream true|false] [--validation-level fast|balanced|strict] [--fallback-mode auto|off] [--minimum-profile standard|off] [--exa-key KEY] [--context7-key KEY] [--zhipu-key KEY] [--zhipu-api-url URL] [--zhipu-search-engine ENGINE] [--tavily-api-url URL] [--tavily-key KEY] [--firecrawl-api-url URL] [--firecrawl-key KEY] [--anysearch-api-url URL] [--anysearch-key KEY] [--anysearch-timeout SECONDS] [--format json|markdown|content] [--output PATH]`
+- `smart-search setup [--lang zh|en] [--advanced] [--non-interactive] [--skip-skills] [--install-skills CSV] [--skills-root PATH] [--xai-api-url URL] [--xai-api-key KEY] [--xai-model ID] [--xai-tools-explicit CSV] [--openai-compatible-api-url URL] [--openai-compatible-api-key KEY] [--openai-compatible-model ID] [--openai-compatible-stream true|false] [--validation-level fast|balanced|strict] [--fallback-mode auto|off] [--minimum-profile standard|off] [--exa-key KEY] [--context7-key KEY] [--zhipu-key KEY] [--zhipu-api-url URL] [--zhipu-search-engine ENGINE] [--zhipu-mcp-key KEY] [--zhipu-mcp-search-api-url URL] [--zhipu-mcp-reader-api-url URL] [--zhipu-mcp-zread-api-url URL] [--zhipu-mcp-timeout SECONDS] [--jina-key KEY] [--jina-reader-api-url URL] [--jina-respond-with MODE] [--jina-timeout SECONDS] [--tavily-api-url URL] [--tavily-key KEY] [--firecrawl-api-url URL] [--firecrawl-key KEY] [--anysearch-api-url URL] [--anysearch-key KEY] [--anysearch-timeout SECONDS] [--format json|markdown|content] [--output PATH]`
 - `smart-search config path [--format json|markdown|content] [--output PATH]`
 - `smart-search config list [--format json|markdown|content] [--output PATH]`
 - `smart-search config set KEY VALUE [--format json|markdown|content] [--output PATH]`
@@ -55,6 +60,11 @@ Top-level aliases must normalize to the same service behavior as their full comm
 | `exa-search` | `exa`, `x` |
 | `exa-similar` | `xs` |
 | `zhipu-search` | `z`, `zp` |
+| `zhipu-mcp-search` | `zmcp-search` |
+| `zhipu-mcp-reader` | `zmcp-reader` |
+| `zhipu-mcp-search-doc` | `zmcp-doc` |
+| `zhipu-mcp-repo-structure` | `zmcp-tree` |
+| `zhipu-mcp-read-file` | `zmcp-file` |
 | `anysearch-domains` | `as-domains` |
 | `anysearch-search` | `as-search`, `as` |
 | `anysearch-extract` | `as-extract` |
@@ -104,7 +114,7 @@ Exa domain filters:
 - This normalization is intentional for Windows PowerShell, where an unquoted comma expression can be forwarded through `.ps1` wrappers as a space-separated value.
 - `source_warning`: non-empty when extra source candidates were appended.
 
-Fetch output includes `ok`, `url`, `provider`, `content`, and `elapsed_ms`.
+Fetch output includes `ok`, `url`, `provider`, `content`, `provider_attempts`, `fallback_used`, and `elapsed_ms`.
 
 Zhipu Web Search API setup:
 
@@ -117,6 +127,25 @@ Zhipu Web Search API setup:
 - `zhipu-search` corresponds to Zhipu Web Search API, not Zhipu Chat Completions `tools=[web_search]`, not Search Agent, and not the MCP Server.
 - `TAVILY_API_URL` only affects Tavily and does not proxy Zhipu.
 - `TAVILY_TIMEOUT_SECONDS` controls the Tavily `doctor` connectivity timeout. It defaults to `30` so slower pooled/community endpoints are not incorrectly marked unhealthy by the diagnostic check.
+
+Zhipu Coding Plan Remote MCP setup:
+
+- `ZHIPU_MCP_API_KEY` configures the Coding Plan MCP auth token and must be sent as `Authorization: Bearer ...`; it must never be logged unmasked.
+- `ZHIPU_MCP_SEARCH_API_URL` defaults to `https://open.bigmodel.cn/api/mcp/web_search_prime/mcp` and calls `webSearchPrime` for `web_search`.
+- `ZHIPU_MCP_READER_API_URL` defaults to `https://open.bigmodel.cn/api/mcp/web_reader/mcp` and calls `webReader` for `web_fetch`.
+- `ZHIPU_MCP_ZREAD_API_URL` defaults to `https://open.bigmodel.cn/api/mcp/zread/mcp` and calls `search_doc`, `get_repo_structure`, and `read_file` through explicit repo/docs commands.
+- Zhipu Coding Plan MCP must be implemented as a separate Remote MCP-over-HTTP provider layer. Do not route it through the existing `/paas/v4/web_search` Zhipu REST provider.
+- Provider failures must appear in `provider_attempts` and fallback must remain same-capability.
+- `doctor` should report configured/not-configured, auth, rate-limit, provider, timeout, and network status without exposing the MCP token.
+
+Jina Reader setup:
+
+- `JINA_READER_API_URL` defaults to `https://r.jina.ai`.
+- `JINA_API_KEY` is required before Jina satisfies `SMART_SEARCH_MINIMUM_PROFILE=standard`.
+- Anonymous Jina Reader calls may be used only as explicit/experimental degraded fetch behavior; they must not make standard setup pass.
+- `JINA_RESPOND_WITH=readerlm-v2` requires `JINA_API_KEY` and should report a configuration error without a network request when the key is missing.
+- Jina Reader is `web_fetch` only, not `web_search`.
+- Jina 401/403, 422, 429, timeout, network errors, and low-quality challenge pages such as `Title: Just a moment...` must be reported as failed provider attempts and allow same-capability fallback.
 
 OpenAI-compatible streaming:
 
@@ -142,6 +171,8 @@ Exa HTTP `400` or `422` failures are returned as `ok=false` with `error_type=par
 Exa similar output includes `ok`, `url`, `results`, `total`, and `elapsed_ms` when successful.
 
 Zhipu search output includes `ok`, `query`, `provider`, `search_engine`, `results`, `total`, and `elapsed_ms` when successful.
+
+Zhipu MCP command output includes `ok`, `provider`, `tool`, `elapsed_ms`, and either `content` for reader/file-like tools or `results` plus `total` for search-like tools.
 
 Context7 library output includes `ok`, `query`, `provider`, `results`, `total`, and `elapsed_ms` when successful. Context7 docs output includes `ok`, `library_id`, `query`, `provider`, `results`, `total`, `content`, and `elapsed_ms` when successful.
 
@@ -300,18 +331,21 @@ Agent timeout handling contract:
 - Chat Completions mode must not send xAI `web_search` / `x_search` tools or legacy `search_parameters`; xAI Chat Completions Live Search is deprecated.
 - Standard minimum profile requires `main_search`, `docs_search`, and fetch capability. Missing required capabilities produce a configuration error.
 - Optional experimental `vertical_search` may report AnySearch when `ANYSEARCH_API_KEY` is configured, but it is not part of the `web_search` fallback and is not required by the `standard` minimum profile.
+- Jina satisfies fetch capability only when `JINA_API_KEY` is configured. Anonymous Jina Reader does not satisfy `standard`.
 - Same-capability fallback is allowed; cross-capability fallback is not. Context7 is not used for unrelated broad web queries, and page extraction providers are not used as docs search providers.
 - `main_search`: xAI Responses first for Grok/xAI, then OpenAI-compatible answer fallback when that peer provider is separately configured and `--fallback auto` is active.
-- `web_search`: Zhipu first when routed in, then Tavily / Firecrawl source search when configured.
+- `web_search`: Zhipu Web Search API first when routed in, then Zhipu Coding Plan MCP `webSearchPrime`, then Tavily / Firecrawl source search when configured.
 - `docs_search`: Context7 first for library/API/docs intent, then Exa for official-domain, paper, product-page, trusted-site, or low-noise supplemental discovery.
-- Fetch capability: Tavily first, then Firecrawl.
+- Fetch capability: Tavily first, then Jina Reader with `JINA_API_KEY`, then Zhipu Coding Plan MCP `webReader`, then Firecrawl.
 - `search` calls Tavily and/or Firecrawl only when `--extra-sources` is greater than 0.
 - If both Tavily and Firecrawl are configured, `search --extra-sources N` gives about 60% of extra source slots to Tavily and the remainder to Firecrawl.
 - `extra_sources` are retrieved in parallel and are not automatically used by the primary model to verify its answer.
-- `fetch` tries Tavily first, then Firecrawl as fallback when Tavily returns no content.
+- `fetch` and known-URL `search "https://..."` use the same fetch fallback chain.
+- `fetch` tries Tavily first, then Jina Reader with `JINA_API_KEY`, then Zhipu Coding Plan MCP Reader, then Firecrawl.
 - `map` uses Tavily only.
 - `exa-search` and `exa-similar` use Exa only.
 - `zhipu-search` uses Zhipu only.
+- `zhipu-mcp-search`, `zhipu-mcp-reader`, and `zhipu-mcp-*` zread commands use Zhipu Coding Plan Remote MCP only.
 - `anysearch-domains`, `anysearch-search`, `anysearch-extract`, and `anysearch-batch` use AnySearch only and do not participate in default fallback chains.
 - `context7-library` and `context7-docs` use Context7 only.
 - Runtime config priority is environment variables first, then local config file, then defaults.

--- a/src/smart_search/assets/skills/smart-search-cli/references/cli-contract.md
+++ b/src/smart_search/assets/skills/smart-search-cli/references/cli-contract.md
@@ -33,6 +33,7 @@
 - `smart-search context7-library NAME [QUERY] [--format json|markdown|content] [--output PATH]`
 - `smart-search context7-docs LIBRARY_ID QUERY [--format json|markdown|content] [--output PATH]`
 - `smart-search deep QUERY [--budget quick|standard|deep] [--evidence-dir PATH] [--format json|markdown|content] [--output PATH]`
+- `smart-search research QUERY [--budget quick|standard|deep] [--evidence-dir PATH] [--fallback auto|off] [--format json|markdown|content] [--output PATH]`
 - `smart-search map URL [--instructions TEXT] [--max-depth N] [--max-breadth N] [--limit N] [--timeout SECONDS] [--format json|markdown|content] [--output PATH]`
 - `smart-search doctor [--format json|markdown|content] [--output PATH]`
 - `smart-search diagnose openai-compatible [--timeout SECONDS] [--format json|markdown] [--output PATH]`
@@ -72,6 +73,7 @@ Top-level aliases must normalize to the same service behavior as their full comm
 | `context7-library` | `c7`, `ctx7` |
 | `context7-docs` | `c7d`, `c7docs`, `ctx7-docs` |
 | `deep` | `dr` |
+| `research` | `rs` |
 | `doctor` | `d` |
 | `diagnose` | `diag` |
 | `setup` | `init` |
@@ -99,7 +101,7 @@ Successful search output includes `ok`, `query`, `primary_api_mode`, `content`, 
 
 `--format markdown` is the human-readable report format. `doctor --format markdown` must render a detailed diagnostic report with overall status, active/default/legacy config paths, log path resolution, file-logging status, masked config values with sources, minimum profile, capability status, main-search provider checks, provider connectivity checks, model metadata, and full long error/message detail instead of falling back to raw JSON. `diagnose openai-compatible --format markdown` must render a short copy-pasteable troubleshooting report with masked config, quick chat check, real search-shape `stream=false` and `stream=true` checks, a plain-language summary, and a next command. Provider list commands such as `exa-search`, `exa-similar`, `zhipu-search`, `anysearch-*`, `context7-library`, and `map` render result lists or a clear no-results message.
 
-`--format content` prints only the `content` field for content-bearing commands such as `search`, `fetch`, and `context7-docs`. Commands without a `content` field, including `doctor`, `smoke`, `config`, and `model`, must print a compact non-empty text summary rather than an empty stdout.
+`--format content` prints only the `content` field for content-bearing commands such as `search`, `fetch`, `context7-docs`, and `research`. Commands without a `content` field, including `doctor`, `smoke`, `config`, and `model`, must print a compact non-empty text summary rather than an empty stdout.
 
 Source provenance fields:
 
@@ -178,7 +180,9 @@ Context7 library output includes `ok`, `query`, `provider`, `results`, `total`, 
 
 Map output includes `ok`, `base_url`, `results`, `response_time`, `url`, and `elapsed_ms` when successful.
 
-Deep planner output includes `ok`, `mode`, `query_mode`, `question`, `trigger_source`, `difficulty`, `intent_signals`, `decomposition`, `capability_plan`, `evidence_policy`, `preflight`, `steps`, `gap_check`, `final_answer_policy`, `usage_boundary`, `allowed_tools`, `evidence_dir`, and `elapsed_ms`. `smart-search deep` is offline by default: `preflight.executed_by_deep_command=false`, no provider calls are made, and live research only happens when an AI agent or user executes `steps[].command`.
+Deep planner output includes `ok`, `mode`, `query_mode`, `question`, `trigger_source`, `difficulty`, `intent_signals`, `decomposition`, `capability_plan`, `evidence_policy`, `preflight`, `steps`, `gap_check`, `final_answer_policy`, `usage_boundary`, `allowed_tools`, `evidence_dir`, and `elapsed_ms`. `smart-search deep` is offline by default: `preflight.executed_by_deep_command=false`, no provider calls are made, and live research only happens when an AI agent or user executes `steps[].command` or calls `smart-search research`.
+
+Research executor output includes `ok`, `mode=deep_research_execution`, `query_mode=research`, `question`, `budget`, `research_plan`, `routing_decision`, `stage_results`, `discovery_sources`, `final_answer`, `content`, `citations`, `evidence_items`, `gap_check`, `provider_attempts`, `providers_used`, `fallback_used`, `degraded`, `route_policy_version`, `evidence_dir`, `minimum_profile_ok`, `capability_status`, and `elapsed_ms`. Citations must come only from fetched/read `evidence_items`; discovery sources are candidates until fetched. If evidence cannot close, `research` returns degraded gaps instead of unsupported claims.
 
 Diagnostic output masks keys, reports `config_file` / `config_dir` / `config_dir_source` / `default_config_file` / Windows legacy config metadata / `config_dir_override_value` / `config_dir_override_matches_default` / `log_dir_config_value` / `resolved_log_dir` / `file_logging_enabled` / `config_sources` / `primary_api_mode` / `primary_api_mode_source` / provider timeout values / `capability_status` / `minimum_profile_ok`, and includes `main_search_connection_tests` plus connection test objects for Exa, Tavily, Zhipu, Context7, and Firecrawl. `primary_connection_test` remains as a backward-compatible alias for the first configured main provider check. OpenAI-compatible provider health must be validated through `/chat/completions`; `/models` is supplementary metadata and must not be the health gate. Firecrawl currently reports whether `FIRECRAWL_API_KEY` is configured; it is not a live Firecrawl request.
 
@@ -188,7 +192,7 @@ Smoke output includes `ok`, `mode`, `failed_cases`, `cases`, `provider_attempts`
 
 ## Deep Research Skill Contract
 
-Deep Research is an optional capability orchestration workflow for prompts such as `深度搜索`, `深度调研`, `深入搜索`, `deep search`, `deep research`, multi-source verification, cross-checking, serious review, and selection/comparison research. `smart-search deep` is the public offline planner command for this workflow. It must not change default `smart-search search` behavior and must not execute live providers by default. The AI agent reads the generated plan, composes existing CLI commands, and lets the CLI perform execution and write JSON/Markdown evidence.
+Deep Research is an optional capability orchestration workflow for prompts such as `深度搜索`, `深度调研`, `深入搜索`, `deep search`, `deep research`, multi-source verification, cross-checking, serious review, and selection/comparison research. `smart-search deep` is the public offline planner command for this workflow. `smart-search research` is the public live executor command. It must not change default `smart-search search` behavior. `deep` must not execute live providers by default. `research` executes the staged workflow and writes JSON/Markdown evidence.
 
 Deep Research must not require fixed topic recipe ids such as `current_market_research`, `product_comparison_research`, `technical_docs_research`, `news_or_policy_research`, `claim_verification_research`, or `url_first_research`. Those phrases may appear as prompt examples, but they are not schema modes or routing enums.
 
@@ -234,13 +238,34 @@ Default Deep Research orchestration:
 
 `fetch_before_claim` means key claims must be backed by fetched page content. `primary_sources` and `extra_sources` are discovery candidates until fetched. Final answers should include fetched evidence, unverified candidate sources, and key commands used.
 
+When the user wants the CLI to execute the live workflow directly, call:
+
+```powershell
+smart-search research "question" --budget deep --fallback auto --format json --output C:\tmp\smart-search-evidence\research.json
+```
+
+`research --fallback auto` permits same-capability fallback inside selected routes. `research --fallback off` tries only the first selected provider in each capability route and is for debugging or provider comparison. Dynamic routing may reorder providers only inside the same capability. Every attempt must record capability, provider, status, error type, latency, and result count.
+
+Research provider advantage routing:
+
+- Context7 first for library/API/framework docs and docs retrieval.
+- Exa for official domains, papers, product/company pages, date/domain-filtered low-noise discovery, and adjacent-source discovery.
+- Zhipu REST for Chinese, domestic, current, policy, and announcement searches.
+- Zhipu MCP as a separate Coding Plan quota route through `webSearchPrime` and `webReader`; do not mix it into `/paas/v4/web_search`.
+- Tavily for broad source discovery and site maps.
+- Jina for known public URL, PDF, and arXiv clean extraction; ReaderLM-v2 requires `JINA_API_KEY`.
+- Firecrawl for robust fetch fallback, JS-heavy/dynamic/browser-like extraction, OCR/PDF/structured extraction.
+- AnySearch only when vertical intent is clear, such as CVE, finance, legal, academic, and repository/codebase search.
+
+Safe research overrides are `SMART_SEARCH_RESEARCH_PREFERRED_PROVIDERS` and `SMART_SEARCH_RESEARCH_DISABLED_PROVIDERS`. They may reorder or disable providers only inside capabilities the provider already supports; they must not move a provider across capability boundaries.
+
 Planner closeout lessons:
 
 - Budget limits must not break evidence policy. Even `--budget quick` plans must retain at least one `fetch` step when claim-level conclusions are expected, and retained steps must keep valid `subquestion_id` links.
 - `steps[].command` and `steps[].output_path` are one contract. The `--output` path embedded in the executable command must match `output_path`; otherwise the AI agent cannot reliably find saved evidence.
 - Prefer PowerShell-safe quoted commands in generated plans because Windows users often copy planned steps directly from Markdown or JSON output.
 
-Deep Research smoke coverage is mock-full plus live-limited. Mock-full coverage should cover trigger phrases, normal search requests that should not trigger Deep Research, required `research_plan` fields, allowed tool whitelist, `fetch_before_claim`, evidence paths, capability boundaries, `intent_signals`, `capability_plan`, `gap_check`, simple current prompts such as `深度搜索一下最近的比特币行情`, docs/API prompts, claim-verification prompts, user-provided URL fetch-first flows, missing-provider failure guidance, and the rule that fixed topic recipe ids are not required schema. Live-limited coverage should run `doctor`, one broad `search`, one `exa-search`, and one `fetch` when real keys are available and live checks are expected. If a smoke issue is found, fix the affected docs/code/tests and rerun the affected smoke until it passes or is proven to be an external provider blocker.
+Deep Research smoke coverage is mock-full plus live-limited. Mock-full coverage should cover trigger phrases, normal search requests that should not trigger Deep Research, required `research_plan` fields, allowed tool whitelist, `fetch_before_claim`, evidence paths, capability boundaries, `intent_signals`, `capability_plan`, `gap_check`, simple current prompts such as `深度搜索一下最近的比特币行情`, docs/API prompts, claim-verification prompts, user-provided URL fetch-first flows, missing-provider failure guidance, research provider advantage routing, same-capability research fallback, and the rule that fixed topic recipe ids are not required schema. Live-limited coverage should run `doctor`, one broad `search`, one `exa-search`, and one `fetch` when real keys are available and live checks are expected; add one small `research` smoke when configured keys make it stable. If a smoke issue is found, fix the affected docs/code/tests and rerun the affected smoke until it passes or is proven to be an external provider blocker.
 
 Setup and config output should include `ok` and `config_file`. Saved API keys must be masked in command output.
 
@@ -342,6 +367,7 @@ Agent timeout handling contract:
 - `extra_sources` are retrieved in parallel and are not automatically used by the primary model to verify its answer.
 - `fetch` and known-URL `search "https://..."` use the same fetch fallback chain.
 - `fetch` tries Tavily first, then Jina Reader with `JINA_API_KEY`, then Zhipu Coding Plan MCP Reader, then Firecrawl.
+- `research` uses capability-first plus provider-advantage routing. Fallback remains same-capability only; low-quality fetches, challenge pages, empty content, auth/rate/timeout/provider errors, and runtime errors are failed attempts that may trigger same-capability fallback.
 - `map` uses Tavily only.
 - `exa-search` and `exa-similar` use Exa only.
 - `zhipu-search` uses Zhipu only.

--- a/src/smart_search/assets/skills/smart-search-cli/references/cli-contract.md
+++ b/src/smart_search/assets/skills/smart-search-cli/references/cli-contract.md
@@ -137,6 +137,7 @@ Zhipu Coding Plan Remote MCP setup:
 - `ZHIPU_MCP_READER_API_URL` defaults to `https://open.bigmodel.cn/api/mcp/web_reader/mcp` and calls `webReader` for `web_fetch`.
 - `ZHIPU_MCP_ZREAD_API_URL` defaults to `https://open.bigmodel.cn/api/mcp/zread/mcp` and calls `search_doc`, `get_repo_structure`, and `read_file` through explicit repo/docs commands.
 - Zhipu Coding Plan MCP must be implemented as a separate Remote MCP-over-HTTP provider layer. Do not route it through the existing `/paas/v4/web_search` Zhipu REST provider.
+- A normal Zhipu Web Search API key is not sufficient evidence of Coding Plan entitlement. If `ZHIPU_MCP_API_KEY` is missing or returns auth/provider errors, MCP providers are skipped or fall through within the same capability; zread remains explicit and does not affect the standard minimum profile.
 - Provider failures must appear in `provider_attempts` and fallback must remain same-capability.
 - `doctor` should report configured/not-configured, auth, rate-limit, provider, timeout, and network status without exposing the MCP token.
 

--- a/src/smart_search/assets/skills/smart-search-cli/references/cli-contract.md
+++ b/src/smart_search/assets/skills/smart-search-cli/references/cli-contract.md
@@ -133,7 +133,7 @@ Zhipu Web Search API setup:
 Zhipu Coding Plan Remote MCP setup:
 
 - `ZHIPU_MCP_API_KEY` configures the Coding Plan MCP auth token and must be sent as `Authorization: Bearer ...`; it must never be logged unmasked.
-- `ZHIPU_MCP_SEARCH_API_URL` defaults to `https://open.bigmodel.cn/api/mcp/web_search_prime/mcp` and calls `webSearchPrime` for `web_search`.
+- `ZHIPU_MCP_SEARCH_API_URL` defaults to `https://open.bigmodel.cn/api/mcp/web_search_prime/mcp` and calls `web_search_prime` for `web_search`.
 - `ZHIPU_MCP_READER_API_URL` defaults to `https://open.bigmodel.cn/api/mcp/web_reader/mcp` and calls `webReader` for `web_fetch`.
 - `ZHIPU_MCP_ZREAD_API_URL` defaults to `https://open.bigmodel.cn/api/mcp/zread/mcp` and calls `search_doc`, `get_repo_structure`, and `read_file` through explicit repo/docs commands.
 - Zhipu Coding Plan MCP must be implemented as a separate Remote MCP-over-HTTP provider layer. Do not route it through the existing `/paas/v4/web_search` Zhipu REST provider.
@@ -251,7 +251,7 @@ Research provider advantage routing:
 - Context7 first for library/API/framework docs and docs retrieval.
 - Exa for official domains, papers, product/company pages, date/domain-filtered low-noise discovery, and adjacent-source discovery.
 - Zhipu REST for Chinese, domestic, current, policy, and announcement searches.
-- Zhipu MCP as a separate Coding Plan quota route through `webSearchPrime` and `webReader`; do not mix it into `/paas/v4/web_search`.
+- Zhipu MCP as a separate Coding Plan quota route through `web_search_prime` and `webReader`; do not mix it into `/paas/v4/web_search`.
 - Tavily for broad source discovery and site maps.
 - Jina for known public URL, PDF, and arXiv clean extraction; ReaderLM-v2 requires `JINA_API_KEY`.
 - Firecrawl for robust fetch fallback, JS-heavy/dynamic/browser-like extraction, OCR/PDF/structured extraction.
@@ -359,7 +359,7 @@ Agent timeout handling contract:
 - Jina satisfies fetch capability only when `JINA_API_KEY` is configured. Anonymous Jina Reader does not satisfy `standard`.
 - Same-capability fallback is allowed; cross-capability fallback is not. Context7 is not used for unrelated broad web queries, and page extraction providers are not used as docs search providers.
 - `main_search`: xAI Responses first for Grok/xAI, then OpenAI-compatible answer fallback when that peer provider is separately configured and `--fallback auto` is active.
-- `web_search`: Zhipu Web Search API first when routed in, then Zhipu Coding Plan MCP `webSearchPrime`, then Tavily / Firecrawl source search when configured.
+- `web_search`: Zhipu Web Search API first when routed in, then Zhipu Coding Plan MCP `web_search_prime`, then Tavily / Firecrawl source search when configured.
 - `docs_search`: Context7 first for library/API/docs intent, then Exa for official-domain, paper, product-page, trusted-site, or low-noise supplemental discovery.
 - Fetch capability: Tavily first, then Jina Reader with `JINA_API_KEY`, then Zhipu Coding Plan MCP `webReader`, then Firecrawl.
 - `search` calls Tavily and/or Firecrawl only when `--extra-sources` is greater than 0.

--- a/src/smart_search/cli.py
+++ b/src/smart_search/cli.py
@@ -34,6 +34,11 @@ COMMAND_ALIASES = {
     "exa-search": ["exa", "x"],
     "exa-similar": ["xs"],
     "zhipu-search": ["z", "zp"],
+    "zhipu-mcp-search": ["zmcp-search"],
+    "zhipu-mcp-reader": ["zmcp-reader"],
+    "zhipu-mcp-search-doc": ["zmcp-doc"],
+    "zhipu-mcp-repo-structure": ["zmcp-tree"],
+    "zhipu-mcp-read-file": ["zmcp-file"],
     "anysearch-domains": ["as-domains"],
     "anysearch-search": ["as-search", "as"],
     "anysearch-extract": ["as-extract"],
@@ -435,8 +440,10 @@ def _format_doctor_markdown(data: dict[str, Any]) -> str:
     provider_tests = [
         ("exa", data.get("exa_connection_test") or {}),
         ("tavily", data.get("tavily_connection_test") or {}),
+        ("jina", data.get("jina_connection_test") or {}),
         ("firecrawl", data.get("firecrawl_connection_test") or {}),
         ("zhipu", data.get("zhipu_connection_test") or {}),
+        ("zhipu-mcp", data.get("zhipu_mcp_connection_test") or {}),
         ("context7", data.get("context7_connection_test") or {}),
     ]
     rows = []
@@ -779,6 +786,11 @@ def _format_markdown(command: str, data: dict[str, Any]) -> str:
         "exa-search": "Exa Search",
         "exa-similar": "Exa Similar Pages",
         "zhipu-search": "Zhipu Search",
+        "zhipu-mcp-search": "Zhipu Coding Plan MCP Search",
+        "zhipu-mcp-reader": "Zhipu Coding Plan MCP Reader",
+        "zhipu-mcp-search-doc": "Zhipu Coding Plan MCP Search Doc",
+        "zhipu-mcp-repo-structure": "Zhipu Coding Plan MCP Repo Structure",
+        "zhipu-mcp-read-file": "Zhipu Coding Plan MCP Read File",
         "anysearch-domains": "AnySearch Domains",
         "anysearch-search": "AnySearch Search",
         "anysearch-extract": "AnySearch Extract",
@@ -902,6 +914,11 @@ def _format_content(command: str, data: dict[str, Any]) -> str:
         "exa-search",
         "exa-similar",
         "zhipu-search",
+        "zhipu-mcp-search",
+        "zhipu-mcp-reader",
+        "zhipu-mcp-search-doc",
+        "zhipu-mcp-repo-structure",
+        "zhipu-mcp-read-file",
         "anysearch-domains",
         "anysearch-search",
         "anysearch-extract",
@@ -1028,8 +1045,11 @@ def _display_provider(provider: str, lang: str) -> str:
         "xai-responses": "xAI Responses",
         "openai-compatible": "OpenAI-compatible",
         "zhipu": _t(lang, "智谱", "Zhipu"),
+        "zhipu-mcp": _t(lang, "智谱 Coding Plan MCP", "Zhipu Coding Plan MCP"),
+        "zhipu-mcp-reader": _t(lang, "智谱 MCP Reader", "Zhipu MCP Reader"),
         "exa": "Exa",
         "context7": "Context7",
+        "jina": "Jina Reader",
         "tavily": "Tavily",
         "firecrawl": "Firecrawl",
         "anysearch": "AnySearch",
@@ -1084,6 +1104,10 @@ def _normalize_zhipu_api_url(url: str) -> str:
     return _normalize_custom_base_url(url)
 
 
+def _normalize_jina_reader_api_url(url: str) -> str:
+    return _normalize_custom_base_url(url)
+
+
 def _is_tavily_hikari_key(api_key: str) -> bool:
     return api_key.strip().lower().startswith("th-")
 
@@ -1112,12 +1136,13 @@ def _setup_status_from_values(values: dict[str, str]) -> dict[str, Any]:
                 provider
                 for provider, configured in [
                     ("zhipu", has("ZHIPU_API_KEY")),
+                    ("zhipu-mcp", has("ZHIPU_MCP_API_KEY")),
                     ("tavily", has("TAVILY_API_KEY")),
                     ("firecrawl", has("FIRECRAWL_API_KEY")),
                 ]
                 if configured
             ],
-            "fallback_chain": ["zhipu", "tavily", "firecrawl"],
+            "fallback_chain": ["zhipu", "zhipu-mcp", "tavily", "firecrawl"],
         },
         "docs_search": {
             "configured": [
@@ -1135,11 +1160,13 @@ def _setup_status_from_values(values: dict[str, str]) -> dict[str, Any]:
                 provider
                 for provider, configured in [
                     ("tavily", has("TAVILY_API_KEY")),
+                    ("jina", has("JINA_API_KEY")),
+                    ("zhipu-mcp-reader", has("ZHIPU_MCP_API_KEY")),
                     ("firecrawl", has("FIRECRAWL_API_KEY")),
                 ]
                 if configured
             ],
-            "fallback_chain": ["tavily", "firecrawl"],
+            "fallback_chain": ["tavily", "jina", "zhipu-mcp-reader", "firecrawl"],
         },
         "vertical_search": {
             "configured": ["anysearch"] if has("ANYSEARCH_API_KEY") else [],
@@ -1664,8 +1691,8 @@ def _prompt_web_fetch(values: dict[str, str], current: dict[str, str], lang: str
     _write_stderr(
         _t(
             lang,
-            "\n[3/3 必选] web_fetch 网页抓取\n用途: 已知 URL 抓正文；高风险事实核验必须用。\n推荐: Tavily 优先；Firecrawl 可作为抓取兜底。\n",
-            "\n[3/3 Required] web_fetch page fetch\nPurpose: extract known URLs; required for high-risk fact checks.\nRecommended: Tavily first; Firecrawl as fetch fallback.\n",
+            "\n[3/3 必选] web_fetch 网页抓取\n用途: 已知 URL 抓正文；高风险事实核验必须用。\n推荐: Tavily 优先；Jina 需要 key 才算标准配置；Firecrawl 可作为抓取兜底。\n",
+            "\n[3/3 Required] web_fetch page fetch\nPurpose: extract known URLs; required for high-risk fact checks.\nRecommended: Tavily first; Jina requires a key to satisfy standard config; Firecrawl as fetch fallback.\n",
         )
     )
     selected = _prompt_provider_multi_select(
@@ -1674,13 +1701,23 @@ def _prompt_web_fetch(values: dict[str, str], current: dict[str, str], lang: str
             "选择 web_fetch provider",
             "Choose web_fetch providers",
         ),
-        ["tavily", "firecrawl"],
+        ["tavily", "jina", "firecrawl"],
         default_selected,
         lang,
     )
     if "tavily" in selected:
         values["TAVILY_API_KEY"] = _prompt_value("TAVILY_API_KEY", "Tavily API key", current.get("TAVILY_API_KEY", ""), lang=lang)
         _prompt_tavily_api_url(values, current, lang)
+    if "jina" in selected:
+        values["JINA_API_KEY"] = _prompt_value("JINA_API_KEY", "Jina API key", current.get("JINA_API_KEY", ""), lang=lang)
+        raw_url = _prompt_value(
+            "JINA_READER_API_URL",
+            "Jina Reader API URL",
+            current.get("JINA_READER_API_URL", "https://r.jina.ai"),
+            optional=True,
+            lang=lang,
+        )
+        values["JINA_READER_API_URL"] = _normalize_jina_reader_api_url(raw_url)
     if "firecrawl" in selected:
         values["FIRECRAWL_API_KEY"] = _prompt_value(
             "FIRECRAWL_API_KEY",
@@ -1834,6 +1871,15 @@ def _run_advanced_setup_prompts(values: dict[str, str], current: dict[str, str],
         ("ZHIPU_API_KEY", "Zhipu API key", True),
         ("ZHIPU_API_URL", "Zhipu Web Search API URL", True),
         ("ZHIPU_SEARCH_ENGINE", "Zhipu search service (search_std/search_pro/search_pro_sogou/search_pro_quark/custom)", True),
+        ("ZHIPU_MCP_API_KEY", "Zhipu Coding Plan MCP API key", True),
+        ("ZHIPU_MCP_SEARCH_API_URL", "Zhipu Coding Plan search MCP URL", True),
+        ("ZHIPU_MCP_READER_API_URL", "Zhipu Coding Plan reader MCP URL", True),
+        ("ZHIPU_MCP_ZREAD_API_URL", "Zhipu Coding Plan zread MCP URL", True),
+        ("ZHIPU_MCP_TIMEOUT_SECONDS", "Zhipu Coding Plan MCP timeout seconds", True),
+        ("JINA_API_KEY", "Jina API key", True),
+        ("JINA_READER_API_URL", "Jina Reader API URL", True),
+        ("JINA_RESPOND_WITH", "Jina respond-with mode (optional, e.g. readerlm-v2)", True),
+        ("JINA_TIMEOUT_SECONDS", "Jina timeout seconds", True),
         ("TAVILY_API_URL", "Tavily API URL", True),
         ("TAVILY_API_KEY", "Tavily API key", True),
         ("FIRECRAWL_API_URL", "Firecrawl API URL", True),
@@ -1852,6 +1898,10 @@ def _run_advanced_setup_prompts(values: dict[str, str], current: dict[str, str],
             value = _normalize_firecrawl_api_url(value)
         elif key == "ZHIPU_API_URL":
             value = _normalize_zhipu_api_url(value)
+        elif key == "JINA_READER_API_URL":
+            value = _normalize_jina_reader_api_url(value)
+        elif key in {"ZHIPU_MCP_SEARCH_API_URL", "ZHIPU_MCP_READER_API_URL", "ZHIPU_MCP_ZREAD_API_URL"}:
+            value = _normalize_custom_base_url(value)
         values[key] = value
 
 
@@ -1915,6 +1965,21 @@ async def _run_async(args: argparse.Namespace) -> int:
             content_size=args.content_size,
         )
         return _print_result("zhipu-search", data, args.format, args.output)
+    if args.command == "zhipu-mcp-search":
+        data = await service.zhipu_mcp_search(args.query, count=args.count)
+        return _print_result("zhipu-mcp-search", data, args.format, args.output)
+    if args.command == "zhipu-mcp-reader":
+        data = await service.zhipu_mcp_reader(args.url)
+        return _print_result("zhipu-mcp-reader", data, args.format, args.output)
+    if args.command == "zhipu-mcp-search-doc":
+        data = await service.zhipu_mcp_search_doc(args.repo, args.query, max_results=args.max_results)
+        return _print_result("zhipu-mcp-search-doc", data, args.format, args.output)
+    if args.command == "zhipu-mcp-repo-structure":
+        data = await service.zhipu_mcp_repo_structure(args.repo, ref=args.ref)
+        return _print_result("zhipu-mcp-repo-structure", data, args.format, args.output)
+    if args.command == "zhipu-mcp-read-file":
+        data = await service.zhipu_mcp_read_file(args.repo, args.path, ref=args.ref)
+        return _print_result("zhipu-mcp-read-file", data, args.format, args.output)
     if args.command == "anysearch-domains":
         data = await service.anysearch_domains(args.domain)
         return _print_result("anysearch-domains", data, args.format, args.output)
@@ -2046,6 +2111,15 @@ def _run_setup(args: argparse.Namespace) -> int:
         "ZHIPU_API_KEY": args.zhipu_key,
         "ZHIPU_API_URL": _normalize_zhipu_api_url(args.zhipu_api_url),
         "ZHIPU_SEARCH_ENGINE": args.zhipu_search_engine,
+        "ZHIPU_MCP_API_KEY": args.zhipu_mcp_key,
+        "ZHIPU_MCP_SEARCH_API_URL": _normalize_custom_base_url(args.zhipu_mcp_search_api_url),
+        "ZHIPU_MCP_READER_API_URL": _normalize_custom_base_url(args.zhipu_mcp_reader_api_url),
+        "ZHIPU_MCP_ZREAD_API_URL": _normalize_custom_base_url(args.zhipu_mcp_zread_api_url),
+        "ZHIPU_MCP_TIMEOUT_SECONDS": args.zhipu_mcp_timeout,
+        "JINA_API_KEY": args.jina_key,
+        "JINA_READER_API_URL": _normalize_jina_reader_api_url(args.jina_reader_api_url),
+        "JINA_RESPOND_WITH": args.jina_respond_with,
+        "JINA_TIMEOUT_SECONDS": args.jina_timeout,
         "TAVILY_API_URL": _normalize_tavily_flag_api_url(args.tavily_api_url, args.tavily_key),
         "TAVILY_API_KEY": args.tavily_key,
         "FIRECRAWL_API_URL": _normalize_firecrawl_api_url(args.firecrawl_api_url),
@@ -2122,6 +2196,8 @@ def _run_regression() -> int:
         "tests/test_cli.py",
         "tests/test_service.py",
         "tests/test_providers_new.py",
+        "tests/test_jina_provider.py",
+        "tests/test_zhipu_mcp_provider.py",
         "tests/test_smoke.py",
         "tests/test_regression.py",
         "tests/test_release_workflow.py",
@@ -2212,6 +2288,57 @@ def build_parser() -> argparse.ArgumentParser:
     zhipu_parser.add_argument("--search-domain-filter", default="")
     zhipu_parser.add_argument("--content-size", choices=["medium", "high"], default="medium")
     _add_format_args(zhipu_parser)
+
+    zhipu_mcp_search_parser = sub.add_parser(
+        "zhipu-mcp-search",
+        aliases=COMMAND_ALIASES["zhipu-mcp-search"],
+        help="Run Zhipu Coding Plan Remote MCP webSearchPrime.",
+    )
+    zhipu_mcp_search_parser.set_defaults(command="zhipu-mcp-search")
+    zhipu_mcp_search_parser.add_argument("query")
+    zhipu_mcp_search_parser.add_argument("--count", type=int, default=5)
+    _add_format_args(zhipu_mcp_search_parser)
+
+    zhipu_mcp_reader_parser = sub.add_parser(
+        "zhipu-mcp-reader",
+        aliases=COMMAND_ALIASES["zhipu-mcp-reader"],
+        help="Run Zhipu Coding Plan Remote MCP webReader.",
+    )
+    zhipu_mcp_reader_parser.set_defaults(command="zhipu-mcp-reader")
+    zhipu_mcp_reader_parser.add_argument("url")
+    _add_format_args(zhipu_mcp_reader_parser)
+
+    zhipu_mcp_search_doc_parser = sub.add_parser(
+        "zhipu-mcp-search-doc",
+        aliases=COMMAND_ALIASES["zhipu-mcp-search-doc"],
+        help="Search repository docs through Zhipu Coding Plan zread MCP.",
+    )
+    zhipu_mcp_search_doc_parser.set_defaults(command="zhipu-mcp-search-doc")
+    zhipu_mcp_search_doc_parser.add_argument("repo")
+    zhipu_mcp_search_doc_parser.add_argument("query")
+    zhipu_mcp_search_doc_parser.add_argument("--max-results", type=int, default=5)
+    _add_format_args(zhipu_mcp_search_doc_parser)
+
+    zhipu_mcp_repo_structure_parser = sub.add_parser(
+        "zhipu-mcp-repo-structure",
+        aliases=COMMAND_ALIASES["zhipu-mcp-repo-structure"],
+        help="Read repository structure through Zhipu Coding Plan zread MCP.",
+    )
+    zhipu_mcp_repo_structure_parser.set_defaults(command="zhipu-mcp-repo-structure")
+    zhipu_mcp_repo_structure_parser.add_argument("repo")
+    zhipu_mcp_repo_structure_parser.add_argument("--ref", default="")
+    _add_format_args(zhipu_mcp_repo_structure_parser)
+
+    zhipu_mcp_read_file_parser = sub.add_parser(
+        "zhipu-mcp-read-file",
+        aliases=COMMAND_ALIASES["zhipu-mcp-read-file"],
+        help="Read a repository file through Zhipu Coding Plan zread MCP.",
+    )
+    zhipu_mcp_read_file_parser.set_defaults(command="zhipu-mcp-read-file")
+    zhipu_mcp_read_file_parser.add_argument("repo")
+    zhipu_mcp_read_file_parser.add_argument("path")
+    zhipu_mcp_read_file_parser.add_argument("--ref", default="")
+    _add_format_args(zhipu_mcp_read_file_parser)
 
     anysearch_domains_parser = sub.add_parser(
         "anysearch-domains",
@@ -2398,6 +2525,15 @@ def build_parser() -> argparse.ArgumentParser:
     setup_parser.add_argument("--zhipu-key", default="", help="Save ZHIPU_API_KEY.")
     setup_parser.add_argument("--zhipu-api-url", default="", help="Save ZHIPU_API_URL.")
     setup_parser.add_argument("--zhipu-search-engine", default="", help="Save ZHIPU_SEARCH_ENGINE.")
+    setup_parser.add_argument("--zhipu-mcp-key", default="", help="Save ZHIPU_MCP_API_KEY.")
+    setup_parser.add_argument("--zhipu-mcp-search-api-url", default="", help="Save ZHIPU_MCP_SEARCH_API_URL.")
+    setup_parser.add_argument("--zhipu-mcp-reader-api-url", default="", help="Save ZHIPU_MCP_READER_API_URL.")
+    setup_parser.add_argument("--zhipu-mcp-zread-api-url", default="", help="Save ZHIPU_MCP_ZREAD_API_URL.")
+    setup_parser.add_argument("--zhipu-mcp-timeout", default="", help="Save ZHIPU_MCP_TIMEOUT_SECONDS.")
+    setup_parser.add_argument("--jina-key", default="", help="Save JINA_API_KEY.")
+    setup_parser.add_argument("--jina-reader-api-url", default="", help="Save JINA_READER_API_URL.")
+    setup_parser.add_argument("--jina-respond-with", default="", help="Save JINA_RESPOND_WITH, e.g. readerlm-v2.")
+    setup_parser.add_argument("--jina-timeout", default="", help="Save JINA_TIMEOUT_SECONDS.")
     setup_parser.add_argument("--tavily-api-url", default="", help="Save TAVILY_API_URL.")
     setup_parser.add_argument("--tavily-key", default="", help="Save TAVILY_API_KEY.")
     setup_parser.add_argument("--firecrawl-api-url", default="", help="Save FIRECRAWL_API_URL.")

--- a/src/smart_search/cli.py
+++ b/src/smart_search/cli.py
@@ -2331,7 +2331,7 @@ def build_parser() -> argparse.ArgumentParser:
     zhipu_mcp_search_parser = sub.add_parser(
         "zhipu-mcp-search",
         aliases=COMMAND_ALIASES["zhipu-mcp-search"],
-        help="Run Zhipu Coding Plan Remote MCP webSearchPrime.",
+        help="Run Zhipu Coding Plan Remote MCP web_search_prime.",
     )
     zhipu_mcp_search_parser.set_defaults(command="zhipu-mcp-search")
     zhipu_mcp_search_parser.add_argument("query")

--- a/src/smart_search/cli.py
+++ b/src/smart_search/cli.py
@@ -46,6 +46,7 @@ COMMAND_ALIASES = {
     "context7-library": ["c7", "ctx7"],
     "context7-docs": ["c7d", "c7docs", "ctx7-docs"],
     "deep": ["dr"],
+    "research": ["rs"],
     "smoke": ["sm"],
     "doctor": ["d"],
     "diagnose": ["diag"],
@@ -767,6 +768,36 @@ def _format_markdown(command: str, data: dict[str, Any]) -> str:
         if gap_check:
             lines.extend(["", "## Gap Check", gap_check.get("rule", "")])
         return "\n".join(lines).strip() + "\n"
+    if command == "research":
+        lines = [
+            "# Research Report",
+            "",
+            f"**Question:** {data.get('question', '')}",
+            f"**Status:** {_status_label(data.get('ok'))}",
+            f"**Route policy:** {data.get('route_policy_version', '')}",
+            f"**Evidence dir:** `{data.get('evidence_dir', '')}`",
+            f"**Fallback used:** {bool(data.get('fallback_used'))}",
+            f"**Degraded:** {bool(data.get('degraded'))}",
+            "",
+            "## Answer",
+            data.get("final_answer") or data.get("content") or "",
+        ]
+        citations = data.get("citations") or []
+        if citations:
+            lines.extend(["", "## Citations"])
+            for item in citations:
+                url = item.get("url", "")
+                title = item.get("title") or url
+                provider = item.get("provider") or ""
+                lines.append(f"- [{title}]({url})" + (f" ({provider})" if provider else ""))
+        gaps = (data.get("gap_check") or {}).get("gaps") or []
+        if gaps:
+            lines.extend(["", "## Gaps"])
+            for gap in gaps:
+                reason = gap.get("reason", "")
+                url = gap.get("url", "")
+                lines.append(f"- {reason}" + (f" - {url}" if url else ""))
+        return "\n".join(lines).strip() + "\n"
     if command == "doctor":
         return _format_doctor_markdown(data)
     if command == "diagnose":
@@ -821,7 +852,7 @@ def _plain_result_lines(data: dict[str, Any]) -> list[str]:
 
 
 def _format_content(command: str, data: dict[str, Any]) -> str:
-    if command in {"search", "fetch", "context7-docs"}:
+    if command in {"search", "fetch", "context7-docs", "research"}:
         content = data.get("content")
         if content:
             return str(content) + "\n"
@@ -2010,6 +2041,14 @@ async def _run_async(args: argparse.Namespace) -> int:
             evidence_dir=args.evidence_dir,
         )
         return _print_result("deep", data, args.format, args.output)
+    if args.command == "research":
+        data = await service.research(
+            args.query,
+            budget=args.budget,
+            evidence_dir=args.evidence_dir,
+            fallback=args.fallback,
+        )
+        return _print_result("research", data, args.format, args.output)
     if args.command == "smoke":
         data = await service.smoke(args.mode)
         return _print_result("smoke", data, args.format, args.output)
@@ -2411,6 +2450,18 @@ def build_parser() -> argparse.ArgumentParser:
     deep_parser.add_argument("--budget", choices=["quick", "standard", "deep"], default="standard")
     deep_parser.add_argument("--evidence-dir", default="")
     _add_format_args(deep_parser)
+
+    research_parser = sub.add_parser(
+        "research",
+        aliases=COMMAND_ALIASES["research"],
+        help="Run live Deep Research with provider-advantage routing and evidence-only synthesis.",
+    )
+    research_parser.set_defaults(command="research")
+    research_parser.add_argument("query")
+    research_parser.add_argument("--budget", choices=["quick", "standard", "deep"], default="deep")
+    research_parser.add_argument("--evidence-dir", default="")
+    research_parser.add_argument("--fallback", choices=["auto", "off"], default="auto")
+    _add_format_args(research_parser)
 
     smoke_parser = sub.add_parser(
         "smoke", aliases=COMMAND_ALIASES["smoke"], help="Run provider routing and fallback smoke checks."

--- a/src/smart_search/config.py
+++ b/src/smart_search/config.py
@@ -41,6 +41,15 @@ class Config:
         "ZHIPU_API_URL",
         "ZHIPU_SEARCH_ENGINE",
         "ZHIPU_TIMEOUT_SECONDS",
+        "ZHIPU_MCP_API_KEY",
+        "ZHIPU_MCP_SEARCH_API_URL",
+        "ZHIPU_MCP_READER_API_URL",
+        "ZHIPU_MCP_ZREAD_API_URL",
+        "ZHIPU_MCP_TIMEOUT_SECONDS",
+        "JINA_API_KEY",
+        "JINA_READER_API_URL",
+        "JINA_RESPOND_WITH",
+        "JINA_TIMEOUT_SECONDS",
         "TAVILY_API_KEY",
         "TAVILY_API_URL",
         "TAVILY_ENABLED",
@@ -498,6 +507,51 @@ class Config:
     def zhipu_timeout(self) -> float:
         return float(self._get_config_value("ZHIPU_TIMEOUT_SECONDS", "30") or "30")
 
+    @property
+    def zhipu_mcp_api_key(self) -> str | None:
+        return self._get_config_value("ZHIPU_MCP_API_KEY")
+
+    @property
+    def zhipu_mcp_search_api_url(self) -> str:
+        return self._get_config_value(
+            "ZHIPU_MCP_SEARCH_API_URL",
+            "https://open.bigmodel.cn/api/mcp/web_search_prime/mcp",
+        ) or "https://open.bigmodel.cn/api/mcp/web_search_prime/mcp"
+
+    @property
+    def zhipu_mcp_reader_api_url(self) -> str:
+        return self._get_config_value(
+            "ZHIPU_MCP_READER_API_URL",
+            "https://open.bigmodel.cn/api/mcp/web_reader/mcp",
+        ) or "https://open.bigmodel.cn/api/mcp/web_reader/mcp"
+
+    @property
+    def zhipu_mcp_zread_api_url(self) -> str:
+        return self._get_config_value(
+            "ZHIPU_MCP_ZREAD_API_URL",
+            "https://open.bigmodel.cn/api/mcp/zread/mcp",
+        ) or "https://open.bigmodel.cn/api/mcp/zread/mcp"
+
+    @property
+    def zhipu_mcp_timeout(self) -> float:
+        return float(self._get_config_value("ZHIPU_MCP_TIMEOUT_SECONDS", "30") or "30")
+
+    @property
+    def jina_api_key(self) -> str | None:
+        return self._get_config_value("JINA_API_KEY")
+
+    @property
+    def jina_reader_api_url(self) -> str:
+        return self._get_config_value("JINA_READER_API_URL", "https://r.jina.ai") or "https://r.jina.ai"
+
+    @property
+    def jina_respond_with(self) -> str:
+        return self._get_config_value("JINA_RESPOND_WITH", "") or ""
+
+    @property
+    def jina_timeout(self) -> float:
+        return float(self._get_config_value("JINA_TIMEOUT_SECONDS", "30") or "30")
+
     def get_config_info(self) -> dict:
         config_parameter_errors: list[str] = []
         explicit_main_configured = bool(
@@ -568,6 +622,15 @@ class Config:
             "ZHIPU_API_URL": self.zhipu_api_url,
             "ZHIPU_SEARCH_ENGINE": self.zhipu_search_engine,
             "ZHIPU_TIMEOUT_SECONDS": self.zhipu_timeout,
+            "ZHIPU_MCP_API_KEY": self._mask_api_key(self.zhipu_mcp_api_key) if self.zhipu_mcp_api_key else "未配置",
+            "ZHIPU_MCP_SEARCH_API_URL": self.zhipu_mcp_search_api_url,
+            "ZHIPU_MCP_READER_API_URL": self.zhipu_mcp_reader_api_url,
+            "ZHIPU_MCP_ZREAD_API_URL": self.zhipu_mcp_zread_api_url,
+            "ZHIPU_MCP_TIMEOUT_SECONDS": self.zhipu_mcp_timeout,
+            "JINA_API_KEY": self._mask_api_key(self.jina_api_key) if self.jina_api_key else "未配置",
+            "JINA_READER_API_URL": self.jina_reader_api_url,
+            "JINA_RESPOND_WITH": self.jina_respond_with,
+            "JINA_TIMEOUT_SECONDS": self.jina_timeout,
             "primary_api_mode": "xai-responses" if self.xai_api_key else ("chat-completions" if self.openai_compatible_api_url and self.openai_compatible_api_key else "未配置"),
             "primary_api_mode_source": "config_file" if explicit_main_configured else "default",
             "config_file": str(self.config_file),

--- a/src/smart_search/config.py
+++ b/src/smart_search/config.py
@@ -31,6 +31,8 @@ class Config:
         "SMART_SEARCH_VALIDATION_LEVEL",
         "SMART_SEARCH_FALLBACK_MODE",
         "SMART_SEARCH_MINIMUM_PROFILE",
+        "SMART_SEARCH_RESEARCH_PREFERRED_PROVIDERS",
+        "SMART_SEARCH_RESEARCH_DISABLED_PROVIDERS",
         "EXA_API_KEY",
         "EXA_BASE_URL",
         "EXA_TIMEOUT_SECONDS",
@@ -381,6 +383,25 @@ class Config:
             self._ALLOWED_MINIMUM_PROFILES,
         )
 
+    def _csv_values(self, key: str) -> list[str]:
+        raw = self._get_config_value(key, "") or ""
+        values: list[str] = []
+        seen: set[str] = set()
+        for item in raw.split(","):
+            value = item.strip().lower()
+            if value and value not in seen:
+                seen.add(value)
+                values.append(value)
+        return values
+
+    @property
+    def research_preferred_providers(self) -> list[str]:
+        return self._csv_values("SMART_SEARCH_RESEARCH_PREFERRED_PROVIDERS")
+
+    @property
+    def research_disabled_providers(self) -> list[str]:
+        return self._csv_values("SMART_SEARCH_RESEARCH_DISABLED_PROVIDERS")
+
     @property
     def tavily_enabled(self) -> bool:
         return (self._get_config_value("TAVILY_ENABLED", "true") or "true").lower() in ("true", "1", "yes")
@@ -594,6 +615,8 @@ class Config:
             "SMART_SEARCH_VALIDATION_LEVEL": validation_level,
             "SMART_SEARCH_FALLBACK_MODE": fallback_mode,
             "SMART_SEARCH_MINIMUM_PROFILE": minimum_profile,
+            "SMART_SEARCH_RESEARCH_PREFERRED_PROVIDERS": ",".join(self.research_preferred_providers),
+            "SMART_SEARCH_RESEARCH_DISABLED_PROVIDERS": ",".join(self.research_disabled_providers),
             "SMART_SEARCH_DEBUG": self.debug_enabled,
             "SMART_SEARCH_LOG_LEVEL": self.log_level,
             "SMART_SEARCH_LOG_DIR": self.log_dir_config_value,

--- a/src/smart_search/providers/__init__.py
+++ b/src/smart_search/providers/__init__.py
@@ -4,7 +4,9 @@ from .context7 import Context7Provider
 from .openai_compatible import OpenAICompatibleSearchProvider
 from .xai_responses import XAIResponsesSearchProvider
 from .exa import ExaSearchProvider
+from .jina import JinaReaderProvider
 from .zhipu import ZhipuWebSearchProvider
+from .zhipu_mcp import ZhipuMCPProvider
 
 __all__ = [
     "BaseSearchProvider",
@@ -14,5 +16,7 @@ __all__ = [
     "OpenAICompatibleSearchProvider",
     "XAIResponsesSearchProvider",
     "ExaSearchProvider",
+    "JinaReaderProvider",
     "ZhipuWebSearchProvider",
+    "ZhipuMCPProvider",
 ]

--- a/src/smart_search/providers/jina.py
+++ b/src/smart_search/providers/jina.py
@@ -1,0 +1,136 @@
+import json
+import time
+from typing import Any
+
+import httpx
+
+
+CHALLENGE_MARKERS = (
+    "title: just a moment",
+    "checking if the site connection is secure",
+    "attention required! | cloudflare",
+    "enable javascript and cookies to continue",
+)
+
+
+def _elapsed_ms(start: float) -> float:
+    return round((time.time() - start) * 1000, 2)
+
+
+def _error_payload(exc: Exception) -> dict[str, str]:
+    if isinstance(exc, httpx.HTTPStatusError):
+        status_code = exc.response.status_code
+        if status_code in {401, 403}:
+            error_type = "auth_error"
+        elif status_code == 422:
+            error_type = "parameter_error"
+        elif status_code == 429:
+            error_type = "rate_limited"
+        else:
+            error_type = "network_error"
+        body = (exc.response.text or exc.response.reason_phrase or "")[:300]
+        return {"error_type": error_type, "error": f"HTTP {status_code}: {body}"}
+    if isinstance(exc, httpx.TimeoutException):
+        return {"error_type": "timeout", "error": "request timed out"}
+    if isinstance(exc, httpx.RequestError):
+        return {"error_type": "network_error", "error": str(exc)}
+    return {"error_type": "runtime_error", "error": str(exc)}
+
+
+def _mask_secret(text: str, secret: str) -> str:
+    return text.replace(secret, "***") if secret else text
+
+
+def _quality_error(content: str) -> str:
+    lower = content.strip().lower()
+    if not lower:
+        return "empty response"
+    for marker in CHALLENGE_MARKERS:
+        if marker in lower:
+            return f"low-quality challenge page detected: {marker}"
+    return ""
+
+
+class JinaReaderProvider:
+    def __init__(
+        self,
+        reader_api_url: str,
+        api_key: str | None = None,
+        respond_with: str = "",
+        timeout: float = 30.0,
+    ):
+        self.reader_api_url = reader_api_url.rstrip("/")
+        self.api_key = api_key or ""
+        self.respond_with = respond_with.strip()
+        self.timeout = timeout
+
+    async def fetch(self, url: str) -> str:
+        start = time.time()
+        if self.respond_with and not self.api_key:
+            return json.dumps(
+                {
+                    "ok": False,
+                    "provider": "jina",
+                    "url": url,
+                    "error_type": "config_error",
+                    "error": "JINA_RESPOND_WITH requires JINA_API_KEY.",
+                    "elapsed_ms": _elapsed_ms(start),
+                },
+                ensure_ascii=False,
+                indent=2,
+            )
+
+        headers = {"X-Return-Format": "markdown", "Accept": "text/plain, text/markdown, */*"}
+        if self.respond_with:
+            headers["X-Respond-With"] = self.respond_with
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+
+        endpoint = f"{self.reader_api_url}/{url}"
+        try:
+            timeout = httpx.Timeout(connect=6.0, read=self.timeout, write=10.0, pool=None)
+            async with httpx.AsyncClient(timeout=timeout, follow_redirects=True) as client:
+                response = await client.get(endpoint, headers=headers)
+                response.raise_for_status()
+            content = response.text.strip()
+            quality_error = _quality_error(content)
+            if quality_error:
+                return json.dumps(
+                    {
+                        "ok": False,
+                        "provider": "jina",
+                        "url": url,
+                        "error_type": "quality_error",
+                        "error": quality_error,
+                        "content": content,
+                        "elapsed_ms": _elapsed_ms(start),
+                    },
+                    ensure_ascii=False,
+                    indent=2,
+                )
+            return json.dumps(
+                {
+                    "ok": True,
+                    "provider": "jina",
+                    "url": url,
+                    "content": content,
+                    "elapsed_ms": _elapsed_ms(start),
+                },
+                ensure_ascii=False,
+                indent=2,
+            )
+        except Exception as e:
+            error = _error_payload(e)
+            message = _mask_secret(error["error"], self.api_key)
+            return json.dumps(
+                {
+                    "ok": False,
+                    "provider": "jina",
+                    "url": url,
+                    "error_type": error["error_type"],
+                    "error": message,
+                    "elapsed_ms": _elapsed_ms(start),
+                },
+                ensure_ascii=False,
+                indent=2,
+            )

--- a/src/smart_search/providers/zhipu_mcp.py
+++ b/src/smart_search/providers/zhipu_mcp.py
@@ -1,0 +1,204 @@
+import json
+import re
+import time
+from typing import Any
+
+import httpx
+
+
+def _elapsed_ms(start: float) -> float:
+    return round((time.time() - start) * 1000, 2)
+
+
+def _error_payload(exc: Exception) -> dict[str, str]:
+    if isinstance(exc, httpx.HTTPStatusError):
+        status_code = exc.response.status_code
+        if status_code in {401, 403}:
+            error_type = "auth_error"
+        elif status_code == 429:
+            error_type = "rate_limited"
+        else:
+            error_type = "network_error"
+        body = (exc.response.text or exc.response.reason_phrase or "")[:300]
+        return {"error_type": error_type, "error": f"HTTP {status_code}: {body}"}
+    if isinstance(exc, httpx.TimeoutException):
+        return {"error_type": "timeout", "error": "request timed out"}
+    if isinstance(exc, httpx.RequestError):
+        return {"error_type": "network_error", "error": str(exc)}
+    return {"error_type": "runtime_error", "error": str(exc)}
+
+
+def _mask_secret(text: str, secret: str) -> str:
+    return text.replace(secret, "***") if secret else text
+
+
+def _extract_text(result: dict[str, Any]) -> str:
+    content = result.get("content") or []
+    if isinstance(content, list):
+        parts = []
+        for item in content:
+            if isinstance(item, dict) and isinstance(item.get("text"), str):
+                parts.append(item["text"])
+        return "\n".join(parts).strip()
+    if isinstance(content, str):
+        return content.strip()
+    return ""
+
+
+def _parse_sse_or_json(response: httpx.Response) -> dict[str, Any]:
+    content_type = response.headers.get("content-type", "")
+    if "json" in content_type:
+        return response.json()
+    data_lines = []
+    for line in response.text.splitlines():
+        line = line.strip()
+        if line.startswith("data:"):
+            data_lines.append(line.removeprefix("data:").strip())
+    for line in reversed(data_lines):
+        if not line or line == "[DONE]":
+            continue
+        try:
+            return json.loads(line)
+        except json.JSONDecodeError:
+            continue
+    return response.json()
+
+
+def _parse_markdown_results(text: str, provider: str) -> list[dict[str, str]]:
+    results: list[dict[str, str]] = []
+    current: dict[str, str] | None = None
+    for line in text.splitlines():
+        heading = re.match(r"^#{2,4}\s+(?:\d+[.)]\s*)?(.+?)\s*$", line.strip())
+        if heading:
+            if current:
+                results.append(current)
+            current = {"title": heading.group(1).strip(), "url": "", "description": "", "provider": provider}
+            continue
+        url_match = re.search(r"https?://[^\s)>\]]+", line)
+        if url_match:
+            if current is None:
+                current = {"title": url_match.group(0), "url": "", "description": "", "provider": provider}
+            current["url"] = current.get("url") or url_match.group(0).rstrip(".,")
+            continue
+        if current is not None and line.strip() and not line.startswith("#"):
+            current["description"] = (current.get("description", "") + " " + line.strip()).strip()
+    if current:
+        results.append(current)
+    if results:
+        return results
+    urls = re.findall(r"https?://[^\s)>\]]+", text)
+    return [{"title": url, "url": url, "description": "", "provider": provider} for url in dict.fromkeys(urls)]
+
+
+class ZhipuMCPProvider:
+    def __init__(self, api_url: str, api_key: str, timeout: float = 30.0, provider_id: str = "zhipu-mcp"):
+        self.api_url = api_url.rstrip("/")
+        self.api_key = api_key
+        self.timeout = timeout
+        self.provider_id = provider_id
+
+    async def call_tool(self, name: str, arguments: dict[str, Any]) -> str:
+        start = time.time()
+        if not self.api_key:
+            return json.dumps(
+                {
+                    "ok": False,
+                    "provider": self.provider_id,
+                    "tool": name,
+                    "error_type": "config_error",
+                    "error": "ZHIPU_MCP_API_KEY is not configured.",
+                    "elapsed_ms": _elapsed_ms(start),
+                },
+                ensure_ascii=False,
+                indent=2,
+            )
+
+        payload = {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {"name": name, "arguments": arguments},
+        }
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+            "Accept": "application/json, text/event-stream",
+        }
+
+        try:
+            timeout = httpx.Timeout(connect=6.0, read=self.timeout, write=10.0, pool=None)
+            async with httpx.AsyncClient(timeout=timeout, follow_redirects=True) as client:
+                response = await client.post(self.api_url, headers=headers, json=payload)
+                response.raise_for_status()
+                data = _parse_sse_or_json(response)
+            output = self._normalize_response(name, arguments, data, start)
+        except Exception as e:
+            error = _error_payload(e)
+            output = {
+                "ok": False,
+                "provider": self.provider_id,
+                "tool": name,
+                "error_type": error["error_type"],
+                "error": _mask_secret(error["error"], self.api_key),
+                "elapsed_ms": _elapsed_ms(start),
+            }
+        return json.dumps(output, ensure_ascii=False, indent=2)
+
+    def _normalize_response(self, name: str, arguments: dict[str, Any], data: dict[str, Any], start: float) -> dict[str, Any]:
+        if "error" in data:
+            error = data.get("error") or {}
+            message = error.get("message") if isinstance(error, dict) else str(error)
+            return {
+                "ok": False,
+                "provider": self.provider_id,
+                "tool": name,
+                "error_type": "provider_error",
+                "error": message or "Zhipu MCP JSON-RPC error",
+                "elapsed_ms": _elapsed_ms(start),
+            }
+
+        result = data.get("result") or {}
+        text = _extract_text(result)
+        is_error = bool(result.get("isError"))
+        output: dict[str, Any] = {
+            "ok": not is_error,
+            "provider": self.provider_id,
+            "tool": name,
+            "content": text,
+            "raw_content": text,
+            "elapsed_ms": _elapsed_ms(start),
+        }
+        for key in ("query", "url", "repo", "path", "ref"):
+            if arguments.get(key):
+                output[key] = arguments[key]
+        if name == "webReader":
+            output["url"] = arguments.get("url", "")
+        else:
+            results = [] if is_error else _parse_markdown_results(text, self.provider_id)
+            output["results"] = results
+            output["total"] = len(results)
+        if is_error:
+            output["error_type"] = "provider_error"
+            output["error"] = text or "Zhipu MCP tool returned isError=true"
+        return output
+
+    async def web_search(self, query: str, count: int = 5) -> str:
+        return await self.call_tool("webSearchPrime", {"query": query, "count": count})
+
+    async def web_reader(self, url: str) -> str:
+        return await self.call_tool("webReader", {"url": url})
+
+    async def search_doc(self, repo: str, query: str, max_results: int = 5) -> str:
+        return await self.call_tool("search_doc", {"repo": repo, "query": query, "max_results": max_results})
+
+    async def get_repo_structure(self, repo: str, ref: str = "") -> str:
+        arguments = {"repo": repo}
+        if ref:
+            arguments["ref"] = ref
+        return await self.call_tool("get_repo_structure", arguments)
+
+    async def read_file(self, repo: str, path: str, ref: str = "") -> str:
+        arguments = {"repo": repo, "path": path}
+        if ref:
+            arguments["ref"] = ref
+        return await self.call_tool("read_file", arguments)

--- a/src/smart_search/providers/zhipu_mcp.py
+++ b/src/smart_search/providers/zhipu_mcp.py
@@ -90,6 +90,27 @@ def _parse_markdown_results(text: str, provider: str) -> list[dict[str, str]]:
     return [{"title": url, "url": url, "description": "", "provider": provider} for url in dict.fromkeys(urls)]
 
 
+def _content_error(text: str) -> tuple[str, str] | None:
+    stripped = (text or "").strip()
+    if not stripped:
+        return None
+    if stripped.lower().startswith("mcp error"):
+        lowered = stripped.lower()
+        error_type = "auth_error" if "-401" in stripped or "api key" in lowered else "provider_error"
+        return error_type, stripped
+    decoded: Any = stripped
+    for _ in range(2):
+        if not isinstance(decoded, str):
+            break
+        try:
+            decoded = json.loads(decoded)
+        except json.JSONDecodeError:
+            break
+    if isinstance(decoded, dict) and decoded.get("error"):
+        return "provider_error", str(decoded.get("error"))
+    return None
+
+
 class ZhipuMCPProvider:
     def __init__(self, api_url: str, api_key: str, timeout: float = 30.0, provider_id: str = "zhipu-mcp"):
         self.api_url = api_url.rstrip("/")
@@ -159,7 +180,8 @@ class ZhipuMCPProvider:
 
         result = data.get("result") or {}
         text = _extract_text(result)
-        is_error = bool(result.get("isError"))
+        content_error = _content_error(text)
+        is_error = bool(result.get("isError")) or bool(content_error)
         output: dict[str, Any] = {
             "ok": not is_error,
             "provider": self.provider_id,
@@ -178,27 +200,28 @@ class ZhipuMCPProvider:
             output["results"] = results
             output["total"] = len(results)
         if is_error:
-            output["error_type"] = "provider_error"
-            output["error"] = text or "Zhipu MCP tool returned isError=true"
+            output["error_type"] = content_error[0] if content_error else "provider_error"
+            output["error"] = content_error[1] if content_error else (text or "Zhipu MCP tool returned isError=true")
         return output
 
     async def web_search(self, query: str, count: int = 5) -> str:
-        return await self.call_tool("webSearchPrime", {"query": query, "count": count})
+        del count
+        return await self.call_tool("web_search_prime", {"search_query": query})
 
     async def web_reader(self, url: str) -> str:
         return await self.call_tool("webReader", {"url": url})
 
     async def search_doc(self, repo: str, query: str, max_results: int = 5) -> str:
-        return await self.call_tool("search_doc", {"repo": repo, "query": query, "max_results": max_results})
+        del max_results
+        return await self.call_tool("search_doc", {"repo_name": repo, "query": query})
 
     async def get_repo_structure(self, repo: str, ref: str = "") -> str:
-        arguments = {"repo": repo}
+        arguments = {"repo_name": repo}
         if ref:
-            arguments["ref"] = ref
+            arguments["dir_path"] = ref
         return await self.call_tool("get_repo_structure", arguments)
 
     async def read_file(self, repo: str, path: str, ref: str = "") -> str:
-        arguments = {"repo": repo, "path": path}
-        if ref:
-            arguments["ref"] = ref
+        del ref
+        arguments = {"repo_name": repo, "file_path": path}
         return await self.call_tool("read_file", arguments)

--- a/src/smart_search/service.py
+++ b/src/smart_search/service.py
@@ -13,9 +13,11 @@ from .logger import log_info
 from .providers.anysearch import AnySearchProvider
 from .providers.context7 import Context7Provider
 from .providers.exa import ExaSearchProvider
+from .providers.jina import JinaReaderProvider
 from .providers.openai_compatible import OpenAICompatibleSearchProvider, get_local_time_info
 from .providers.xai_responses import XAIResponsesSearchProvider
 from .providers.zhipu import ZhipuWebSearchProvider
+from .providers.zhipu_mcp import ZhipuMCPProvider
 from .sources import merge_sources, new_session_id, split_answer_and_sources
 from .utils import search_prompt
 
@@ -81,6 +83,11 @@ DEEP_ALLOWED_TOOLS = {
     "exa-search",
     "exa-similar",
     "zhipu-search",
+    "zhipu-mcp-search",
+    "zhipu-mcp-reader",
+    "zhipu-mcp-search-doc",
+    "zhipu-mcp-repo-structure",
+    "zhipu-mcp-read-file",
     "context7-library",
     "context7-docs",
     "fetch",
@@ -645,12 +652,13 @@ def get_capability_status() -> dict[str, Any]:
                 name
                 for name, enabled in [
                     ("zhipu", bool(config.zhipu_api_key)),
+                    ("zhipu-mcp", bool(config.zhipu_mcp_api_key)),
                     ("tavily", bool(config.tavily_api_key)),
                     ("firecrawl", bool(config.firecrawl_api_key)),
                 ]
                 if enabled
             ],
-            "fallback_chain": ["zhipu", "tavily", "firecrawl"],
+            "fallback_chain": ["zhipu", "zhipu-mcp", "tavily", "firecrawl"],
         },
         "docs_search": {
             "configured": [
@@ -668,11 +676,13 @@ def get_capability_status() -> dict[str, Any]:
                 name
                 for name, enabled in [
                     ("tavily", bool(config.tavily_api_key)),
+                    ("jina", bool(config.jina_api_key)),
+                    ("zhipu-mcp-reader", bool(config.zhipu_mcp_api_key)),
                     ("firecrawl", bool(config.firecrawl_api_key)),
                 ]
                 if enabled
             ],
-            "fallback_chain": ["tavily", "firecrawl"],
+            "fallback_chain": ["tavily", "jina", "zhipu-mcp-reader", "firecrawl"],
         },
         "vertical_search": {
             "configured": ["anysearch"] if config.anysearch_api_key else [],
@@ -871,6 +881,10 @@ async def _run_web_fetch_fallback(url: str, fallback: str = "auto") -> tuple[dic
     providers = []
     if config.tavily_api_key:
         providers.append("tavily")
+    if config.jina_api_key:
+        providers.append("jina")
+    if config.zhipu_mcp_api_key:
+        providers.append("zhipu-mcp-reader")
     if config.firecrawl_api_key:
         providers.append("firecrawl")
     if fallback == "off":
@@ -881,6 +895,20 @@ async def _run_web_fetch_fallback(url: str, fallback: str = "auto") -> tuple[dic
         try:
             if provider == "tavily":
                 content = await call_tavily_extract(url)
+            elif provider == "jina":
+                data = await jina_fetch(url)
+                content = data.get("content") if data.get("ok") else None
+                if not data.get("ok"):
+                    status = "error" if data.get("error_type") in {"auth_error", "config_error", "parameter_error", "quality_error", "rate_limited", "timeout", "network_error", "runtime_error"} else "empty"
+                    attempts.append(_attempt("web_fetch", provider, status, start, error_type=data.get("error_type", ""), error=data.get("error", "")))
+                    continue
+            elif provider == "zhipu-mcp-reader":
+                data = await zhipu_mcp_reader(url)
+                content = data.get("content") if data.get("ok") else None
+                if not data.get("ok"):
+                    status = "error" if data.get("error_type") in {"auth_error", "config_error", "provider_error", "rate_limited", "timeout", "network_error", "runtime_error"} else "empty"
+                    attempts.append(_attempt("web_fetch", provider, status, start, error_type=data.get("error_type", ""), error=data.get("error", "")))
+                    continue
             else:
                 content = await call_firecrawl_scrape(url)
             if content and content.strip():
@@ -908,6 +936,8 @@ async def _run_web_search_fallback(
     configured: list[str] = []
     if config.zhipu_api_key:
         configured.append("zhipu")
+    if config.zhipu_mcp_api_key:
+        configured.append("zhipu-mcp")
     if config.tavily_api_key:
         configured.append("tavily")
     if config.firecrawl_api_key:
@@ -928,6 +958,15 @@ async def _run_web_search_fallback(
                         attempts.append(_attempt("web_search", provider, "ok", start, result_count=len(sources)))
                         return sources, attempts
                 status = "error" if data.get("error_type") in {"rate_limited", "auth_error", "timeout", "network_error", "runtime_error"} else "empty"
+                attempts.append(_attempt("web_search", provider, status, start, error_type=data.get("error_type", ""), error=data.get("error", "")))
+            elif provider == "zhipu-mcp":
+                data = await zhipu_mcp_search(query, count=count)
+                if data.get("ok"):
+                    sources = _normalize_source_results(data.get("results"), "zhipu-mcp")
+                    if sources:
+                        attempts.append(_attempt("web_search", provider, "ok", start, result_count=len(sources)))
+                        return sources, attempts
+                status = "error" if data.get("error_type") in {"rate_limited", "auth_error", "timeout", "network_error", "runtime_error", "provider_error"} else "empty"
                 attempts.append(_attempt("web_search", provider, status, start, error_type=data.get("error_type", ""), error=data.get("error", "")))
             elif provider == "tavily":
                 results = await call_tavily_search(query, count)
@@ -1105,6 +1144,16 @@ async def call_firecrawl_scrape(url: str, ctx=None) -> str | None:
     return None
 
 
+async def call_jina_reader(url: str) -> dict[str, Any]:
+    raw = await JinaReaderProvider(
+        config.jina_reader_api_url,
+        config.jina_api_key,
+        config.jina_respond_with,
+        config.jina_timeout,
+    ).fetch(url)
+    return await _decode_provider_json(raw, provider="jina")
+
+
 async def call_tavily_map(
     url: str,
     instructions: str = "",
@@ -1223,7 +1272,8 @@ async def search(
     docs_intent = _is_docs_intent(query)
     zh_current_intent = _is_zh_current_intent(query)
     web_current_intent = zh_current_intent
-    fetch_intent = _is_fetch_intent(query)
+    fetch_urls = _extract_urls(query)
+    fetch_intent = bool(fetch_urls) or _is_fetch_intent(query)
     supplemental_paths: list[str] = []
     if docs_intent:
         supplemental_paths.append("docs_search")
@@ -1331,7 +1381,8 @@ async def search(
             provider_attempts.extend(web_attempts)
             supplemental_sources.extend(web_sources)
         if fetch_intent:
-            fetch_result, fetch_attempts = await _run_web_fetch_fallback(query.strip(), fallback=fallback_mode)
+            fetch_url = fetch_urls[0] if fetch_urls else query.strip()
+            fetch_result, fetch_attempts = await _run_web_fetch_fallback(fetch_url, fallback=fallback_mode)
             provider_attempts.extend(fetch_attempts)
             if fetch_result:
                 supplemental_sources.append({"url": fetch_result["url"], "provider": fetch_result["provider"], "description": fetch_result["content"][:300]})
@@ -1445,39 +1496,17 @@ def _primary_search_error_result(
 
 async def fetch(url: str) -> dict[str, Any]:
     start = time.time()
-    attempts: list[dict] = []
-    tavily_start = time.time()
-    tavily_result = await call_tavily_extract(url)
-    if tavily_result:
-        attempts.append(_attempt("web_fetch", "tavily", "ok", tavily_start, result_count=1))
+    fetch_result, attempts = await _run_web_fetch_fallback(url)
+    if fetch_result:
         return {
-            "ok": True,
-            "url": url,
-            "provider": "tavily",
-            "content": tavily_result,
+            **fetch_result,
             "provider_attempts": attempts,
-            "fallback_used": False,
+            "fallback_used": _fallback_used(attempts),
             "elapsed_ms": _elapsed_ms(start),
         }
-    attempts.append(_attempt("web_fetch", "tavily", "empty", tavily_start))
 
-    firecrawl_start = time.time()
-    firecrawl_result = await call_firecrawl_scrape(url)
-    if firecrawl_result:
-        attempts.append(_attempt("web_fetch", "firecrawl", "ok", firecrawl_start, result_count=1))
-        return {
-            "ok": True,
-            "url": url,
-            "provider": "firecrawl",
-            "content": firecrawl_result,
-            "provider_attempts": attempts,
-            "fallback_used": True,
-            "elapsed_ms": _elapsed_ms(start),
-        }
-    attempts.append(_attempt("web_fetch", "firecrawl", "empty", firecrawl_start))
-
-    if not config.tavily_api_key and not config.firecrawl_api_key:
-        error = "TAVILY_API_KEY 和 FIRECRAWL_API_KEY 均未配置"
+    if not (config.tavily_api_key or config.jina_api_key or config.zhipu_mcp_api_key or config.firecrawl_api_key):
+        error = "TAVILY_API_KEY、JINA_API_KEY、ZHIPU_MCP_API_KEY 和 FIRECRAWL_API_KEY 均未配置"
         error_type = "config_error"
     else:
         error = "所有提取服务均未能获取内容"
@@ -1557,11 +1586,11 @@ def _anysearch_provider() -> AnySearchProvider:
     return AnySearchProvider(config.anysearch_api_url, config.anysearch_api_key, config.anysearch_timeout)
 
 
-async def _decode_provider_json(raw: str) -> dict[str, Any]:
+async def _decode_provider_json(raw: str, provider: str = "anysearch") -> dict[str, Any]:
     try:
         return json.loads(raw)
     except json.JSONDecodeError:
-        return {"ok": False, "provider": "anysearch", "error_type": "parse_error", "error": raw}
+        return {"ok": False, "provider": provider, "error_type": "parse_error", "error": raw}
 
 
 async def anysearch_domains(domain: str = "") -> dict[str, Any]:
@@ -1585,6 +1614,57 @@ async def anysearch_extract(url: str, max_length: int = 20000) -> dict[str, Any]
 
 async def anysearch_batch(queries: list[str], max_results: int = 3) -> dict[str, Any]:
     return await _decode_provider_json(await _anysearch_provider().batch_search(queries, max_results=max_results))
+
+
+def _zhipu_mcp_search_provider() -> ZhipuMCPProvider:
+    return ZhipuMCPProvider(
+        config.zhipu_mcp_search_api_url,
+        config.zhipu_mcp_api_key or "",
+        config.zhipu_mcp_timeout,
+        provider_id="zhipu-mcp",
+    )
+
+
+def _zhipu_mcp_reader_provider() -> ZhipuMCPProvider:
+    return ZhipuMCPProvider(
+        config.zhipu_mcp_reader_api_url,
+        config.zhipu_mcp_api_key or "",
+        config.zhipu_mcp_timeout,
+        provider_id="zhipu-mcp-reader",
+    )
+
+
+def _zhipu_mcp_zread_provider() -> ZhipuMCPProvider:
+    return ZhipuMCPProvider(
+        config.zhipu_mcp_zread_api_url,
+        config.zhipu_mcp_api_key or "",
+        config.zhipu_mcp_timeout,
+        provider_id="zhipu-mcp-zread",
+    )
+
+
+async def jina_fetch(url: str) -> dict[str, Any]:
+    return await call_jina_reader(url)
+
+
+async def zhipu_mcp_search(query: str, count: int = 5) -> dict[str, Any]:
+    return await _decode_provider_json(await _zhipu_mcp_search_provider().web_search(query, count=count), provider="zhipu-mcp")
+
+
+async def zhipu_mcp_reader(url: str) -> dict[str, Any]:
+    return await _decode_provider_json(await _zhipu_mcp_reader_provider().web_reader(url), provider="zhipu-mcp-reader")
+
+
+async def zhipu_mcp_search_doc(repo: str, query: str, max_results: int = 5) -> dict[str, Any]:
+    return await _decode_provider_json(await _zhipu_mcp_zread_provider().search_doc(repo, query, max_results=max_results), provider="zhipu-mcp-zread")
+
+
+async def zhipu_mcp_repo_structure(repo: str, ref: str = "") -> dict[str, Any]:
+    return await _decode_provider_json(await _zhipu_mcp_zread_provider().get_repo_structure(repo, ref=ref), provider="zhipu-mcp-zread")
+
+
+async def zhipu_mcp_read_file(repo: str, path: str, ref: str = "") -> dict[str, Any]:
+    return await _decode_provider_json(await _zhipu_mcp_zread_provider().read_file(repo, path, ref=ref), provider="zhipu-mcp-zread")
 
 
 async def exa_find_similar(url: str, num_results: int = 5) -> dict[str, Any]:
@@ -2106,6 +2186,21 @@ async def _test_tavily_connection() -> dict[str, Any]:
         return {"status": "warning", "message": f"HTTP {resp.status_code}: {resp.text[:100]}", "response_time_ms": response_time}
 
 
+async def _test_jina_connection() -> dict[str, Any]:
+    if config.jina_respond_with and not config.jina_api_key:
+        return {"status": "config_error", "message": "JINA_RESPOND_WITH requires JINA_API_KEY"}
+    if not config.jina_api_key:
+        return {"status": "not_configured", "message": "JINA_API_KEY 未设置，Jina 不满足 standard web_fetch；匿名 Reader 只能作为显式实验使用"}
+    start = time.time()
+    data = await jina_fetch("https://example.com")
+    response_time = _elapsed_ms(start)
+    if data.get("ok"):
+        return {"status": "ok", "message": "Jina Reader 可用", "response_time_ms": response_time}
+    error_type = data.get("error_type", "")
+    status = error_type if error_type in {"auth_error", "config_error", "parameter_error", "rate_limited", "timeout"} else "warning"
+    return {"status": status, "message": data.get("error", "Jina Reader 不可用"), "response_time_ms": response_time}
+
+
 async def _test_zhipu_connection() -> dict[str, Any]:
     if not config.zhipu_api_key:
         return {"status": "not_configured", "message": "ZHIPU_API_KEY 未设置，智谱搜索功能不可用"}
@@ -2113,6 +2208,17 @@ async def _test_zhipu_connection() -> dict[str, Any]:
     if result.get("ok"):
         return {"status": "ok", "message": "智谱 Web Search 可用", "response_time_ms": result.get("elapsed_ms", 0)}
     return {"status": "warning", "message": result.get("error", "智谱 Web Search 不可用"), "response_time_ms": result.get("elapsed_ms", 0)}
+
+
+async def _test_zhipu_mcp_connection() -> dict[str, Any]:
+    if not config.zhipu_mcp_api_key:
+        return {"status": "not_configured", "message": "ZHIPU_MCP_API_KEY 未设置，智谱 Coding Plan MCP 功能不可用"}
+    result = await zhipu_mcp_search("test", count=1)
+    if result.get("ok"):
+        return {"status": "ok", "message": "智谱 Coding Plan MCP 可用", "response_time_ms": result.get("elapsed_ms", 0)}
+    error_type = result.get("error_type", "")
+    status = error_type if error_type in {"auth_error", "config_error", "provider_error", "rate_limited", "timeout"} else "warning"
+    return {"status": status, "message": result.get("error", "智谱 Coding Plan MCP 不可用"), "response_time_ms": result.get("elapsed_ms", 0)}
 
 
 async def _test_context7_connection() -> dict[str, Any]:
@@ -2160,6 +2266,13 @@ async def doctor() -> dict[str, Any]:
     except Exception as e:
         info["tavily_connection_test"] = {"status": "error", "message": str(e)}
 
+    try:
+        info["jina_connection_test"] = await _test_jina_connection()
+    except httpx.TimeoutException:
+        info["jina_connection_test"] = {"status": "timeout", "message": "Jina Reader 请求超时"}
+    except Exception as e:
+        info["jina_connection_test"] = {"status": "error", "message": str(e)}
+
     if config.firecrawl_api_key:
         info["firecrawl_connection_test"] = {"status": "configured", "message": "FIRECRAWL_API_KEY 已设置"}
     else:
@@ -2171,6 +2284,13 @@ async def doctor() -> dict[str, Any]:
         info["zhipu_connection_test"] = {"status": "timeout", "message": "智谱 API 请求超时"}
     except Exception as e:
         info["zhipu_connection_test"] = {"status": "error", "message": str(e)}
+
+    try:
+        info["zhipu_mcp_connection_test"] = await _test_zhipu_mcp_connection()
+    except httpx.TimeoutException:
+        info["zhipu_mcp_connection_test"] = {"status": "timeout", "message": "智谱 Coding Plan MCP 请求超时"}
+    except Exception as e:
+        info["zhipu_mcp_connection_test"] = {"status": "error", "message": str(e)}
 
     try:
         info["context7_connection_test"] = await _test_context7_connection()
@@ -2291,9 +2411,9 @@ async def _smoke_mock(start: float) -> dict[str, Any]:
             "fallback_chain": MAIN_SEARCH_FALLBACK_CHAIN,
             "ok": True,
         },
-        "web_search": {"configured": ["zhipu"], "fallback_chain": ["zhipu", "tavily", "firecrawl"], "ok": True},
+        "web_search": {"configured": ["zhipu"], "fallback_chain": ["zhipu", "zhipu-mcp", "tavily", "firecrawl"], "ok": True},
         "docs_search": {"configured": ["context7"], "fallback_chain": ["context7", "exa"], "ok": True},
-        "web_fetch": {"configured": ["tavily"], "fallback_chain": ["tavily", "firecrawl"], "ok": True},
+        "web_fetch": {"configured": ["tavily"], "fallback_chain": ["tavily", "jina", "zhipu-mcp-reader", "firecrawl"], "ok": True},
         "vertical_search": {"configured": [], "fallback_chain": ["anysearch"], "ok": False, "experimental": True},
     }
     minimum = _minimum_profile_result("standard", minimum_status)
@@ -2486,7 +2606,7 @@ async def _smoke_mock(start: float) -> dict[str, Any]:
         {
             **minimum_status,
             "docs_search": {"configured": [], "fallback_chain": ["context7", "exa"], "ok": False},
-            "web_fetch": {"configured": [], "fallback_chain": ["tavily", "firecrawl"], "ok": False},
+            "web_fetch": {"configured": [], "fallback_chain": ["tavily", "jina", "zhipu-mcp-reader", "firecrawl"], "ok": False},
         },
     )
     cases.append(

--- a/src/smart_search/service.py
+++ b/src/smart_search/service.py
@@ -263,7 +263,7 @@ PROVIDER_PROFILES: dict[str, dict[str, Any]] = {
     },
     "zhipu-mcp": {
         "capability": "web_search",
-        "strengths": ["Coding Plan quota", "remote MCP webSearchPrime"],
+        "strengths": ["Coding Plan quota", "remote MCP web_search_prime"],
         "exclusions": ["Zhipu REST Web Search API"],
         "fallback_group": "web_search",
         "minimum_profile_role": "",

--- a/src/smart_search/service.py
+++ b/src/smart_search/service.py
@@ -1,4 +1,5 @@
 import asyncio
+import hashlib
 import json
 import re
 import time
@@ -162,6 +163,171 @@ DEEP_EXA_DISCOVERY_KEYWORDS = {
     "standard",
     "standards",
 }
+RESEARCH_ROUTE_POLICY_VERSION = "research-router-v1"
+RESEARCH_VERTICAL_KEYWORDS = {
+    "cve",
+    "vulnerability",
+    "vulnerabilities",
+    "安全漏洞",
+    "漏洞",
+    "finance",
+    "financial",
+    "股票",
+    "基金",
+    "财报",
+    "法律",
+    "法规",
+    "legal",
+    "law",
+    "academic",
+    "论文",
+    "paper",
+    "repo",
+    "repository",
+    "github",
+    "gitlab",
+    "codebase",
+    "code search",
+    "code docs",
+    "代码",
+    "代码库",
+    "开源仓库",
+}
+RESEARCH_JS_HEAVY_KEYWORDS = {
+    "js-heavy",
+    "javascript",
+    "dynamic",
+    "动态页面",
+    "浏览器渲染",
+    "登录页",
+    "cloudflare",
+    "screenshot",
+    "ocr",
+    "扫描",
+}
+RESEARCH_PDF_KEYWORDS = {"pdf", "arxiv", "论文", "paper", ".pdf"}
+RESEARCH_PROFILE_ORDER = {
+    "main_search": ["xai-responses", "openai-compatible"],
+    "web_search": ["zhipu", "zhipu-mcp", "tavily", "firecrawl"],
+    "docs_search": ["context7", "exa"],
+    "web_fetch": ["tavily", "jina", "zhipu-mcp-reader", "firecrawl"],
+    "vertical_search": ["anysearch"],
+    "site_map": ["tavily"],
+    "synthesis": ["main-search"],
+}
+PROVIDER_PROFILES: dict[str, dict[str, Any]] = {
+    "xai-responses": {
+        "capability": "main_search",
+        "strengths": ["broad synthesis", "web_search", "x_search"],
+        "exclusions": ["evidence proof without fetch"],
+        "fallback_group": "main_search",
+        "minimum_profile_role": "main_search",
+        "quality_filters": ["source extraction required for high-risk claims"],
+        "route_reasons": ["broad live answer", "primary synthesis"],
+    },
+    "openai-compatible": {
+        "capability": "main_search",
+        "strengths": ["broad synthesis", "relay compatibility"],
+        "exclusions": ["xAI server tools"],
+        "fallback_group": "main_search",
+        "minimum_profile_role": "main_search",
+        "quality_filters": ["source extraction required for high-risk claims"],
+        "route_reasons": ["relay-compatible primary synthesis"],
+    },
+    "context7": {
+        "capability": "docs_search",
+        "strengths": ["library docs", "API docs", "framework docs", "versioned snippets"],
+        "exclusions": ["general news", "generic web facts"],
+        "fallback_group": "docs_search",
+        "minimum_profile_role": "docs_search",
+        "quality_filters": ["library id required", "content required before citation"],
+        "route_reasons": ["docs/API evidence", "framework reference"],
+    },
+    "exa": {
+        "capability": "docs_search",
+        "strengths": ["official domains", "papers", "product pages", "trusted low-noise discovery", "similar pages"],
+        "exclusions": ["default second hop for every high-risk claim"],
+        "fallback_group": "docs_search",
+        "minimum_profile_role": "docs_search",
+        "quality_filters": ["URL required", "fetch before proof citation"],
+        "route_reasons": ["official low-noise discovery", "paper/product discovery"],
+    },
+    "zhipu": {
+        "capability": "web_search",
+        "strengths": ["Chinese", "domestic China", "current", "policy", "announcements", "recency filters"],
+        "exclusions": ["web_fetch", "chat model selection"],
+        "fallback_group": "web_search",
+        "minimum_profile_role": "",
+        "quality_filters": ["URL required", "fetch before proof citation"],
+        "route_reasons": ["Chinese/current/policy discovery"],
+    },
+    "zhipu-mcp": {
+        "capability": "web_search",
+        "strengths": ["Coding Plan quota", "remote MCP webSearchPrime"],
+        "exclusions": ["Zhipu REST Web Search API"],
+        "fallback_group": "web_search",
+        "minimum_profile_role": "",
+        "quality_filters": ["URL required", "fetch before proof citation"],
+        "route_reasons": ["Coding Plan quota web discovery"],
+    },
+    "tavily": {
+        "capability": "web_search",
+        "capabilities": ["web_search", "web_fetch", "site_map"],
+        "strengths": ["broad source discovery", "site map", "URL extract"],
+        "exclusions": ["docs semantic replacement"],
+        "fallback_group": "web_search/web_fetch/site_map",
+        "minimum_profile_role": "web_fetch",
+        "quality_filters": ["non-empty normalized result", "non-empty extracted content"],
+        "route_reasons": ["broad source discovery", "site map", "URL fetch"],
+    },
+    "jina": {
+        "capability": "web_fetch",
+        "strengths": ["known public URL", "PDF", "arXiv", "clean markdown", "ReaderLM-v2 with key"],
+        "exclusions": ["general search provider", "anonymous standard minimum profile"],
+        "fallback_group": "web_fetch",
+        "minimum_profile_role": "web_fetch_with_key",
+        "quality_filters": ["non-empty markdown", "challenge page rejection", "ReaderLM-v2 requires key"],
+        "route_reasons": ["known URL extraction", "PDF/arXiv extraction"],
+    },
+    "zhipu-mcp-reader": {
+        "capability": "web_fetch",
+        "strengths": ["Coding Plan quota", "remote MCP webReader"],
+        "exclusions": ["Zhipu REST Web Search API"],
+        "fallback_group": "web_fetch",
+        "minimum_profile_role": "",
+        "quality_filters": ["non-empty reader content"],
+        "route_reasons": ["Coding Plan quota page read"],
+    },
+    "firecrawl": {
+        "capability": "web_fetch",
+        "capabilities": ["web_search", "web_fetch"],
+        "strengths": ["robust scrape fallback", "JS-heavy pages", "dynamic pages", "OCR/PDF/structured extraction"],
+        "exclusions": ["docs semantic replacement"],
+        "fallback_group": "web_search/web_fetch",
+        "minimum_profile_role": "web_fetch",
+        "quality_filters": ["non-empty normalized result", "non-empty extracted content"],
+        "route_reasons": ["JS-heavy fetch", "dynamic/browser-like extraction", "robust fetch fallback"],
+    },
+    "anysearch": {
+        "capability": "vertical_search",
+        "strengths": ["CVE", "finance", "legal", "academic", "code/docs", "structured vertical domains"],
+        "exclusions": ["generic default fallback", "standard minimum profile"],
+        "fallback_group": "vertical_search",
+        "minimum_profile_role": "",
+        "quality_filters": ["vertical intent required", "URL required before evidence citation"],
+        "route_reasons": ["vertical domain discovery"],
+        "experimental": True,
+    },
+    "main-search": {
+        "capability": "synthesis",
+        "strengths": ["evidence-only final synthesis"],
+        "exclusions": ["live source discovery during research synthesis"],
+        "fallback_group": "synthesis",
+        "minimum_profile_role": "",
+        "quality_filters": ["fetched evidence only", "no provider calls during synthesis"],
+        "route_reasons": ["evidence-only synthesis"],
+    },
+}
 MAIN_SEARCH_FALLBACK_CHAIN = ["xai-responses", "openai-compatible"]
 MAIN_SEARCH_PROVIDER_ALIASES = {
     "xai-responses": {"xai-responses", "xai", "grok", "grok-web-tools"},
@@ -273,12 +439,276 @@ def _provider_names_from_attempts(attempts: list[dict]) -> list[str]:
 
 
 def _fallback_used(attempts: list[dict]) -> bool:
-    by_capability: dict[str, int] = {}
+    by_capability: dict[str, list[dict]] = {}
     for attempt in attempts:
         capability = attempt.get("capability", "")
         if attempt.get("status") in {"ok", "empty", "error"}:
-            by_capability[capability] = by_capability.get(capability, 0) + 1
-    return any(count > 1 for count in by_capability.values())
+            by_capability.setdefault(capability, []).append(attempt)
+    for capability_attempts in by_capability.values():
+        previous_failed = False
+        previous_provider = ""
+        for attempt in capability_attempts:
+            provider = attempt.get("provider", "")
+            status = attempt.get("status")
+            if previous_failed:
+                return True
+            if previous_provider and provider and provider != previous_provider:
+                return True
+            previous_failed = status in {"empty", "error"}
+            previous_provider = provider or previous_provider
+    return False
+
+
+def provider_profiles() -> dict[str, dict[str, Any]]:
+    return {provider: dict(profile) for provider, profile in PROVIDER_PROFILES.items()}
+
+
+def _provider_supports_capability(provider: str, capability: str) -> bool:
+    profile = PROVIDER_PROFILES.get(provider, {})
+    capabilities = set(profile.get("capabilities") or [profile.get("capability", "")])
+    return capability in capabilities
+
+
+def _provider_configured(provider: str) -> bool:
+    if provider == "xai-responses":
+        return bool(config.xai_api_key)
+    if provider == "openai-compatible":
+        return bool(config.openai_compatible_api_url and config.openai_compatible_api_key)
+    if provider == "context7":
+        return bool(config.context7_api_key)
+    if provider == "exa":
+        return bool(config.exa_api_key)
+    if provider == "zhipu":
+        return bool(config.zhipu_api_key)
+    if provider == "zhipu-mcp":
+        return bool(config.zhipu_mcp_api_key)
+    if provider == "tavily":
+        return bool(config.tavily_api_key)
+    if provider == "jina":
+        return bool(config.jina_api_key)
+    if provider == "zhipu-mcp-reader":
+        return bool(config.zhipu_mcp_api_key)
+    if provider == "firecrawl":
+        return bool(config.firecrawl_api_key)
+    if provider == "anysearch":
+        return bool(config.anysearch_api_key)
+    if provider == "main-search":
+        return bool(config.xai_api_key or (config.openai_compatible_api_url and config.openai_compatible_api_key))
+    return False
+
+
+def _configured_for_capability(capability: str, capability_status: dict[str, Any] | None = None) -> list[str]:
+    if capability_status is not None:
+        configured = set(capability_status.get(capability, {}).get("configured") or [])
+        return [
+            provider
+            for provider in RESEARCH_PROFILE_ORDER.get(capability, [])
+            if provider in configured and _provider_supports_capability(provider, capability)
+        ]
+    return [provider for provider in RESEARCH_PROFILE_ORDER.get(capability, []) if _provider_configured(provider)]
+
+
+def _safe_provider_overrides() -> tuple[list[str], list[str], list[str]]:
+    known = set(PROVIDER_PROFILES)
+    preferred = [provider for provider in config.research_preferred_providers if provider in known]
+    disabled = [provider for provider in config.research_disabled_providers if provider in known]
+    invalid = [
+        provider
+        for provider in config.research_preferred_providers + config.research_disabled_providers
+        if provider not in known
+    ]
+    return preferred, disabled, invalid
+
+
+def _apply_research_overrides(capability: str, providers: list[str]) -> list[str]:
+    preferred, disabled, _ = _safe_provider_overrides()
+    allowed = [
+        provider
+        for provider in providers
+        if provider not in disabled and _provider_supports_capability(provider, capability)
+    ]
+    ordered = [
+        provider
+        for provider in preferred
+        if provider in allowed and _provider_supports_capability(provider, capability)
+    ]
+    ordered.extend(provider for provider in allowed if provider not in ordered)
+    return ordered
+
+
+def _research_fetch_order(query: str, url: str = "", capability_status: dict[str, Any] | None = None) -> list[str]:
+    providers = _configured_for_capability("web_fetch", capability_status)
+    target = f"{query} {url}".lower()
+    if _contains_any(target, RESEARCH_JS_HEAVY_KEYWORDS):
+        preferred = ["firecrawl", "tavily", "jina", "zhipu-mcp-reader"]
+    elif _contains_any(target, RESEARCH_PDF_KEYWORDS) or url.lower().endswith(".pdf"):
+        preferred = ["jina", "tavily", "zhipu-mcp-reader", "firecrawl"]
+    elif url or _extract_urls(query):
+        preferred = ["jina", "tavily", "zhipu-mcp-reader", "firecrawl"]
+    else:
+        preferred = providers
+    ordered = [provider for provider in preferred if provider in providers]
+    ordered.extend(provider for provider in providers if provider not in ordered)
+    return _apply_research_overrides("web_fetch", ordered)
+
+
+def _research_route_signals(question: str, plan: dict[str, Any]) -> dict[str, Any]:
+    intent = plan.get("intent_signals") or {}
+    text = question.lower()
+    return {
+        "docs_api_intent": bool(intent.get("docs_api_intent")) or _is_docs_intent(question),
+        "official_low_noise_intent": _contains_any(question, DEEP_EXA_DISCOVERY_KEYWORDS),
+        "current_or_locale_intent": intent.get("recency_requirement") in {"recent", "current"}
+        or intent.get("locale_domain_scope") == "china"
+        or _is_zh_current_intent(question),
+        "known_url": bool(intent.get("known_url")) or bool(_extract_urls(question)),
+        "pdf_or_arxiv_intent": _contains_any(question, RESEARCH_PDF_KEYWORDS),
+        "js_heavy_intent": _contains_any(question, RESEARCH_JS_HEAVY_KEYWORDS),
+        "vertical_intent": _contains_any(question, RESEARCH_VERTICAL_KEYWORDS),
+        "claim_risk": intent.get("claim_risk", "medium"),
+        "cross_validation_need": intent.get("cross_validation_need", "normal"),
+        "raw_query": text,
+    }
+
+
+def _research_capability_routes(
+    question: str,
+    plan: dict[str, Any],
+    fallback: str,
+    capability_status: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    signals = _research_route_signals(question, plan)
+    _, _, invalid_overrides = _safe_provider_overrides()
+    routes: dict[str, Any] = {
+        "signals": signals,
+        "fallback_mode": fallback,
+        "route_policy_version": RESEARCH_ROUTE_POLICY_VERSION,
+        "invalid_provider_overrides": invalid_overrides,
+        "capabilities": {},
+    }
+
+    web_search = _configured_for_capability("web_search", capability_status)
+    if signals["current_or_locale_intent"]:
+        ordered = [provider for provider in ["zhipu", "zhipu-mcp", "tavily", "firecrawl"] if provider in web_search]
+    else:
+        ordered = [provider for provider in ["tavily", "firecrawl", "zhipu", "zhipu-mcp"] if provider in web_search]
+    routes["capabilities"]["web_search"] = {
+        "providers": _apply_research_overrides("web_search", ordered),
+        "reason": "current/locale evidence" if signals["current_or_locale_intent"] else "broad source discovery",
+    }
+
+    docs = _configured_for_capability("docs_search", capability_status)
+    docs_order = [provider for provider in ["context7", "exa"] if provider in docs]
+    if signals["official_low_noise_intent"] and not signals["docs_api_intent"]:
+        docs_order = [provider for provider in ["exa", "context7"] if provider in docs]
+    routes["capabilities"]["docs_search"] = {
+        "providers": _apply_research_overrides("docs_search", docs_order),
+        "reason": "docs/API evidence" if signals["docs_api_intent"] else "official low-noise discovery",
+    }
+
+    fetch_order = _research_fetch_order(question, capability_status=capability_status)
+    routes["capabilities"]["web_fetch"] = {
+        "providers": fetch_order,
+        "reason": "JS-heavy fetch" if signals["js_heavy_intent"] else ("known URL/PDF extraction" if signals["known_url"] or signals["pdf_or_arxiv_intent"] else "evidence extraction"),
+    }
+
+    vertical = _configured_for_capability("vertical_search", capability_status)
+    routes["capabilities"]["vertical_search"] = {
+        "providers": _apply_research_overrides("vertical_search", vertical) if signals["vertical_intent"] else [],
+        "reason": "vertical intent matched" if signals["vertical_intent"] else "vertical intent absent",
+        "experimental": True,
+    }
+
+    return routes
+
+
+def _research_evidence_item(
+    *,
+    url: str,
+    provider: str,
+    title: str = "",
+    content: str = "",
+    source_type: str = "fetched_page",
+    subquestion_id: str = "",
+) -> dict[str, Any]:
+    digest = hashlib.sha1(f"{url}\n{provider}\n{title}".encode("utf-8")).hexdigest()[:12]
+    return {
+        "id": f"e{digest}",
+        "url": url,
+        "title": title or url,
+        "provider": provider,
+        "source_type": source_type,
+        "subquestion_id": subquestion_id,
+        "content": content,
+        "content_len": len(content or ""),
+        "verified": bool(content and content.strip()),
+    }
+
+
+def _citation_items(evidence_items: list[dict[str, Any]]) -> list[dict[str, str]]:
+    citations: list[dict[str, str]] = []
+    seen: set[str] = set()
+    for item in evidence_items:
+        url = item.get("url", "")
+        if not url or url in seen:
+            continue
+        seen.add(url)
+        citations.append({
+            "url": url,
+            "title": item.get("title") or url,
+            "provider": item.get("provider") or "",
+        })
+    return citations
+
+
+def _evidence_only_synthesis(question: str, evidence_items: list[dict[str, Any]], gaps: list[dict[str, Any]]) -> str:
+    if not evidence_items:
+        return (
+            f"未能为 `{question}` 获取可引用的页面正文证据。"
+            "本次 research 已停止在降级状态，未对缺证据的结论做断言。"
+        )
+    lines = [f"Research result for: {question}", ""]
+    lines.append("Evidence-backed findings:")
+    for index, item in enumerate(evidence_items, 1):
+        content = re.sub(r"\s+", " ", (item.get("content") or "").strip())
+        excerpt = content[:360]
+        lines.append(f"{index}. {item.get('title') or item.get('url')} ({item.get('provider')})")
+        if excerpt:
+            lines.append(f"   Evidence excerpt: {excerpt}")
+        lines.append(f"   Source: {item.get('url')}")
+    if gaps:
+        lines.extend(["", "Unverified gaps:"])
+        for gap in gaps:
+            lines.append(f"- {gap.get('subquestion_id', '')}: {gap.get('reason', '')}")
+    return "\n".join(lines).strip()
+
+
+def _select_candidate_urls(sources: list[dict[str, Any]], limit: int = 5) -> list[dict[str, Any]]:
+    selected: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for source in sources:
+        url = (source.get("url") or "").strip()
+        if not url or url.startswith("context7:") or url in seen:
+            continue
+        seen.add(url)
+        selected.append(source)
+        if len(selected) >= limit:
+            break
+    return selected
+
+
+def _artifact_path(evidence_root: str, name: str) -> Path:
+    return Path(evidence_root) / name
+
+
+def _write_research_artifact(evidence_root: str, name: str, data: Any) -> None:
+    root = Path(evidence_root)
+    root.mkdir(parents=True, exist_ok=True)
+    path = _artifact_path(evidence_root, name)
+    if isinstance(data, str):
+        path.write_text(data, encoding="utf-8")
+    else:
+        path.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
 
 
 def _is_docs_intent(query: str) -> bool:
@@ -639,6 +1069,249 @@ def build_deep_research_plan(query: str, budget: str = "standard", evidence_dir:
     }
 
 
+async def research(
+    query: str,
+    budget: str = "deep",
+    evidence_dir: str = "",
+    fallback: str = "auto",
+) -> dict[str, Any]:
+    start = time.time()
+    question = query.strip()
+    fallback_mode = (fallback or "auto").strip().lower()
+    if fallback_mode not in {"auto", "off"}:
+        return {
+            "ok": False,
+            "error_type": "parameter_error",
+            "error": f"Invalid fallback mode: {fallback_mode}",
+            "question": question,
+            "mode": "deep_research_execution",
+            "route_policy_version": RESEARCH_ROUTE_POLICY_VERSION,
+            "elapsed_ms": _elapsed_ms(start),
+        }
+
+    minimum = validate_minimum_profile()
+    if not minimum.get("ok"):
+        return {
+            "ok": False,
+            "error_type": minimum.get("error_type", "config_error"),
+            "error": minimum.get("error", MINIMUM_PROFILE_ERROR),
+            "question": question,
+            "mode": "deep_research_execution",
+            "minimum_profile_ok": False,
+            "capability_status": minimum.get("capability_status", {}),
+            "final_answer": "",
+            "citations": [],
+            "evidence_items": [],
+            "gap_check": {
+                "status": "failed",
+                "gaps": [{"subquestion_id": "", "reason": "minimum profile is missing required capabilities"}],
+            },
+            "provider_attempts": [],
+            "fallback_used": False,
+            "degraded": True,
+            "route_policy_version": RESEARCH_ROUTE_POLICY_VERSION,
+            "evidence_dir": evidence_dir,
+            "elapsed_ms": _elapsed_ms(start),
+        }
+
+    plan = build_deep_research_plan(question, budget=_deep_budget(budget or "deep"), evidence_dir=evidence_dir)
+    evidence_root = plan.get("evidence_dir") or _default_evidence_dir(question)
+    routes = _research_capability_routes(question, plan, fallback_mode)
+    provider_attempts: list[dict[str, Any]] = []
+    discovery_sources: list[dict[str, Any]] = []
+    evidence_items: list[dict[str, Any]] = []
+    stage_results: list[dict[str, Any]] = []
+    gaps: list[dict[str, Any]] = []
+
+    _write_research_artifact(evidence_root, "00-plan.json", plan)
+
+    urls = _extract_urls(question)
+    fetch_order = routes["capabilities"]["web_fetch"]["providers"]
+    if urls:
+        for index, url in enumerate(urls, 1):
+            fetch_result, attempts = await _run_web_fetch_fallback(url, fallback=fallback_mode, preferred_order=fetch_order)
+            provider_attempts.extend(attempts)
+            stage_results.append({"stage": "known_url_fetch", "url": url, "ok": bool(fetch_result), "provider_attempts": attempts})
+            if fetch_result:
+                item = _research_evidence_item(
+                    url=fetch_result["url"],
+                    provider=fetch_result["provider"],
+                    title=fetch_result["url"],
+                    content=fetch_result["content"],
+                    subquestion_id="sq1",
+                )
+                evidence_items.append(item)
+                _write_research_artifact(evidence_root, f"{index:02d}-fetch-{fetch_result['provider']}.md", fetch_result["content"])
+            else:
+                gaps.append({"subquestion_id": "sq1", "reason": f"failed to fetch known URL: {url}", "url": url})
+
+    signals = routes["signals"]
+    if signals["docs_api_intent"]:
+        docs_providers = routes["capabilities"]["docs_search"]["providers"]
+        selected_docs_providers = docs_providers[:1] if fallback_mode == "off" else docs_providers
+        if not selected_docs_providers:
+            gaps.append({"subquestion_id": "sq2", "reason": "no configured docs_search provider for docs/API evidence"})
+        for provider in selected_docs_providers:
+            step_start = time.time()
+            if provider == "context7":
+                data = await context7_library(question, question)
+                if data.get("ok") and data.get("results"):
+                    provider_attempts.append(_attempt("docs_search", "context7", "ok", step_start, result_count=len(data.get("results") or [])))
+                    stage_results.append({"stage": "docs_discovery", "provider": "context7", "ok": True, "result_count": len(data.get("results") or [])})
+                    library_id = (data.get("results") or [{}])[0].get("id", "")
+                    if library_id:
+                        docs_start = time.time()
+                        docs_data = await context7_docs(library_id, question)
+                        if docs_data.get("ok") and docs_data.get("content"):
+                            provider_attempts.append(_attempt("docs_search", "context7", "ok", docs_start, result_count=1))
+                            item = _research_evidence_item(
+                                url=f"context7:{library_id}",
+                                provider="context7",
+                                title=library_id,
+                                content=docs_data.get("content", ""),
+                                source_type="docs",
+                                subquestion_id="sq2",
+                            )
+                            evidence_items.append(item)
+                            _write_research_artifact(evidence_root, "docs-context7.md", docs_data.get("content", ""))
+                            break
+                        docs_status = "error" if docs_data.get("error_type") else "empty"
+                        provider_attempts.append(_attempt("docs_search", "context7", docs_status, docs_start, error_type=docs_data.get("error_type", ""), error=docs_data.get("error", "")))
+                    if fallback_mode == "off":
+                        break
+                    continue
+                status = "error" if data.get("error_type") in {"auth_error", "timeout", "network_error", "runtime_error"} else "empty"
+                provider_attempts.append(_attempt("docs_search", "context7", status, step_start, error_type=data.get("error_type", ""), error=data.get("error", "")))
+            elif provider == "exa":
+                data = await exa_search(question, num_results=5, include_highlights=True)
+                if data.get("ok"):
+                    sources = _normalize_source_results(data.get("results"), "exa")
+                    if sources:
+                        provider_attempts.append(_attempt("docs_search", "exa", "ok", step_start, result_count=len(sources)))
+                        discovery_sources.extend(sources)
+                        stage_results.append({"stage": "docs_discovery", "provider": "exa", "ok": True, "result_count": len(sources)})
+                        break
+                provider_attempts.append(_attempt("docs_search", "exa", "error" if data.get("error_type") else "empty", step_start, error_type=data.get("error_type", ""), error=data.get("error", "")))
+
+    should_run_web_discovery = (
+        signals["current_or_locale_intent"]
+        or signals["cross_validation_need"] == "high"
+        or (not evidence_items and not discovery_sources)
+    ) and not (urls and fallback_mode == "off")
+    if should_run_web_discovery:
+        web_provider_order = routes["capabilities"]["web_search"]["providers"]
+        if web_provider_order:
+            web_sources, attempts = await _run_web_search_fallback(
+                question,
+                count=5,
+                providers=",".join(web_provider_order),
+                fallback=fallback_mode,
+            )
+            provider_attempts.extend(attempts)
+            discovery_sources.extend(web_sources)
+            stage_results.append({"stage": "web_discovery", "ok": bool(web_sources), "result_count": len(web_sources), "provider_attempts": attempts})
+        else:
+            gaps.append({"subquestion_id": "", "reason": "no configured web_search provider for discovery"})
+
+    exa_in_selected_docs_route = "exa" in routes["capabilities"]["docs_search"]["providers"]
+    if (
+        fallback_mode != "off"
+        and signals["official_low_noise_intent"]
+        and exa_in_selected_docs_route
+        and not any(source.get("provider") == "exa" for source in discovery_sources)
+    ):
+        exa_start = time.time()
+        data = await exa_search(question, num_results=5, include_highlights=True)
+        if data.get("ok"):
+            sources = _normalize_source_results(data.get("results"), "exa")
+            if sources:
+                provider_attempts.append(_attempt("docs_search", "exa", "ok", exa_start, result_count=len(sources)))
+                discovery_sources.extend(sources)
+        else:
+            provider_attempts.append(_attempt("docs_search", "exa", "error", exa_start, error_type=data.get("error_type", ""), error=data.get("error", "")))
+
+    if signals["vertical_intent"] and routes["capabilities"]["vertical_search"]["providers"]:
+        vertical_start = time.time()
+        data = await anysearch_search(question, max_results=5)
+        if data.get("ok"):
+            sources = _normalize_source_results(data.get("results"), "anysearch")
+            provider_attempts.append(_attempt("vertical_search", "anysearch", "ok" if sources else "empty", vertical_start, result_count=len(sources)))
+            discovery_sources.extend(sources)
+            stage_results.append({"stage": "vertical_discovery", "provider": "anysearch", "ok": bool(sources), "result_count": len(sources)})
+        else:
+            provider_attempts.append(_attempt("vertical_search", "anysearch", "error", vertical_start, error_type=data.get("error_type", ""), error=data.get("error", "")))
+
+    candidates = _select_candidate_urls(discovery_sources, limit=6)
+    fetched_urls = {item.get("url") for item in evidence_items}
+    no_new_evidence = True
+    for index, candidate in enumerate(candidates, 1):
+        url = candidate.get("url", "")
+        if not url or url in fetched_urls:
+            continue
+        order = _research_fetch_order(question, url)
+        fetch_result, attempts = await _run_web_fetch_fallback(url, fallback=fallback_mode, preferred_order=order)
+        provider_attempts.extend(attempts)
+        stage_results.append({"stage": "candidate_fetch", "url": url, "ok": bool(fetch_result), "provider_attempts": attempts})
+        if fetch_result:
+            no_new_evidence = False
+            fetched_urls.add(url)
+            content = fetch_result.get("content", "")
+            item = _research_evidence_item(
+                url=fetch_result["url"],
+                provider=fetch_result["provider"],
+                title=candidate.get("title") or fetch_result["url"],
+                content=content,
+                subquestion_id=candidate.get("subquestion_id", ""),
+            )
+            evidence_items.append(item)
+            _write_research_artifact(evidence_root, f"fetch-{index:02d}-{fetch_result['provider']}.md", content)
+        elif fallback_mode == "off":
+            gaps.append({"subquestion_id": "", "reason": f"fetch failed with fallback off: {url}", "url": url})
+
+    if not evidence_items:
+        gaps.append({"subquestion_id": "", "reason": "no fetched/read evidence items were produced"})
+    elif no_new_evidence and not urls and candidates:
+        gaps.append({"subquestion_id": "", "reason": "discovery produced candidates but no new fetch evidence converged"})
+
+    covered = bool(evidence_items)
+    gap_status = "closed" if covered and not gaps else ("degraded" if evidence_items else "failed")
+    citations = _citation_items(evidence_items)
+    final_answer = _evidence_only_synthesis(question, evidence_items, gaps)
+    result = {
+        "ok": bool(evidence_items),
+        "error_type": "" if evidence_items else "evidence_error",
+        "error": "" if evidence_items else "research could not obtain fetched evidence",
+        "mode": "deep_research_execution",
+        "query_mode": "research",
+        "question": question,
+        "budget": _deep_budget(budget or "deep"),
+        "research_plan": plan,
+        "routing_decision": routes,
+        "stage_results": stage_results,
+        "discovery_sources": discovery_sources,
+        "final_answer": final_answer,
+        "content": final_answer,
+        "citations": citations,
+        "evidence_items": evidence_items,
+        "gap_check": {
+            "status": gap_status,
+            "gaps": gaps,
+            "stop_reason": "evidence_converged" if gap_status == "closed" else ("degraded_with_gaps" if evidence_items else "provider_exhausted"),
+        },
+        "provider_attempts": provider_attempts,
+        "providers_used": _provider_names_from_attempts(provider_attempts),
+        "fallback_used": _fallback_used(provider_attempts),
+        "degraded": bool(gaps),
+        "route_policy_version": RESEARCH_ROUTE_POLICY_VERSION,
+        "evidence_dir": evidence_root,
+        "minimum_profile_ok": minimum.get("ok", False),
+        "capability_status": minimum.get("capability_status", {}),
+        "elapsed_ms": _elapsed_ms(start),
+    }
+    _write_research_artifact(evidence_root, "summary.json", result)
+    return result
+
+
 def get_capability_status() -> dict[str, Any]:
     main_configured = _configured_main_search_provider_ids()
     status = {
@@ -876,7 +1549,11 @@ def extra_results_to_sources(
     return sources
 
 
-async def _run_web_fetch_fallback(url: str, fallback: str = "auto") -> tuple[dict[str, Any] | None, list[dict]]:
+async def _run_web_fetch_fallback(
+    url: str,
+    fallback: str = "auto",
+    preferred_order: list[str] | None = None,
+) -> tuple[dict[str, Any] | None, list[dict]]:
     attempts: list[dict] = []
     providers = []
     if config.tavily_api_key:
@@ -887,6 +1564,11 @@ async def _run_web_fetch_fallback(url: str, fallback: str = "auto") -> tuple[dic
         providers.append("zhipu-mcp-reader")
     if config.firecrawl_api_key:
         providers.append("firecrawl")
+    if preferred_order:
+        allowed = {provider for provider in providers}
+        ordered = [provider for provider in preferred_order if provider in allowed]
+        ordered.extend(provider for provider in providers if provider not in ordered)
+        providers = ordered
     if fallback == "off":
         providers = providers[:1]
 
@@ -2623,6 +3305,76 @@ async def _smoke_mock(start: float) -> dict[str, Any]:
             "deep_research fixed topic recipes are examples not schema",
             schema_modes.isdisjoint(fixed_recipe_ids) and "deep_research" in schema_modes,
             {"schema_modes": sorted(schema_modes), "not_schema_modes": sorted(fixed_recipe_ids)},
+        )
+    )
+
+    mock_research_status = {
+        **minimum_status,
+        "web_search": {
+            "configured": ["zhipu", "zhipu-mcp", "tavily", "firecrawl"],
+            "fallback_chain": ["zhipu", "zhipu-mcp", "tavily", "firecrawl"],
+            "ok": True,
+        },
+        "docs_search": {"configured": ["context7", "exa"], "fallback_chain": ["context7", "exa"], "ok": True},
+        "web_fetch": {
+            "configured": ["tavily", "jina", "zhipu-mcp-reader", "firecrawl"],
+            "fallback_chain": ["tavily", "jina", "zhipu-mcp-reader", "firecrawl"],
+            "ok": True,
+        },
+        "vertical_search": {"configured": ["anysearch"], "fallback_chain": ["anysearch"], "ok": True, "experimental": True},
+    }
+    docs_routes = _research_capability_routes("React useEffect API docs", docs_plan, "auto", capability_status=mock_research_status)
+    zh_routes = _research_capability_routes("今天国内 AI 政策最新公告", market_plan, "auto", capability_status=mock_research_status)
+    pdf_fetch_order = _research_fetch_order("summarize https://arxiv.org/pdf/2401.00001.pdf", capability_status=mock_research_status)
+    dynamic_fetch_order = _research_fetch_order("dynamic javascript cloudflare page", "https://example.com/app", capability_status=mock_research_status)
+    vertical_routes = _research_capability_routes("CVE OpenSSL 漏洞影响范围", claim_plan, "auto", capability_status=mock_research_status)
+
+    cases.append(
+        _case(
+            "research router docs api prefers context7 then exa",
+            docs_routes["capabilities"]["docs_search"]["providers"][:2] == ["context7", "exa"]
+            and docs_routes["capabilities"]["vertical_search"]["providers"] == [],
+            {"routing_decision": docs_routes},
+        )
+    )
+    cases.append(
+        _case(
+            "research router chinese current prefers zhipu web_search",
+            zh_routes["capabilities"]["web_search"]["providers"][0] == "zhipu",
+            {"routing_decision": zh_routes},
+        )
+    )
+    cases.append(
+        _case(
+            "research router known url pdf favors jina fetch",
+            pdf_fetch_order[0] == "jina",
+            {"fetch_order": pdf_fetch_order},
+        )
+    )
+    cases.append(
+        _case(
+            "research router js heavy favors firecrawl fetch",
+            dynamic_fetch_order[0] == "firecrawl",
+            {"fetch_order": dynamic_fetch_order},
+        )
+    )
+    cases.append(
+        _case(
+            "research router vertical intent uses anysearch only when matched",
+            vertical_routes["capabilities"]["vertical_search"]["providers"] == ["anysearch"],
+            {"routing_decision": vertical_routes},
+        )
+    )
+
+    research_fallback_attempts = [
+        _attempt("web_fetch", "jina", "empty", time.time()),
+        _attempt("web_fetch", "firecrawl", "ok", time.time(), result_count=1),
+    ]
+    cases.append(
+        _case(
+            "research fallback remains same capability",
+            _fallback_used(research_fallback_attempts),
+            {"provider_attempts": research_fallback_attempts},
         )
     )
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -53,6 +53,11 @@ def test_each_subcommand_help_exits_successfully(capsys):
         ["exa-search", "--help"],
         ["exa-similar", "--help"],
         ["zhipu-search", "--help"],
+        ["zhipu-mcp-search", "--help"],
+        ["zhipu-mcp-reader", "--help"],
+        ["zhipu-mcp-search-doc", "--help"],
+        ["zhipu-mcp-repo-structure", "--help"],
+        ["zhipu-mcp-read-file", "--help"],
         ["anysearch-domains", "--help"],
         ["anysearch-search", "--help"],
         ["anysearch-extract", "--help"],
@@ -102,6 +107,11 @@ def test_command_aliases_parse_to_canonical_commands():
         (["xs", "https://example.com"], "exa-similar"),
         (["z", "query"], "zhipu-search"),
         (["zp", "query"], "zhipu-search"),
+        (["zmcp-search", "query"], "zhipu-mcp-search"),
+        (["zmcp-reader", "https://example.com"], "zhipu-mcp-reader"),
+        (["zmcp-doc", "owner/repo", "install"], "zhipu-mcp-search-doc"),
+        (["zmcp-tree", "owner/repo"], "zhipu-mcp-repo-structure"),
+        (["zmcp-file", "owner/repo", "README.md"], "zhipu-mcp-read-file"),
         (["as-domains"], "anysearch-domains"),
         (["as-search", "query"], "anysearch-search"),
         (["as", "query"], "anysearch-search"),
@@ -356,7 +366,7 @@ def test_doctor_markdown_outputs_human_health_report(monkeypatch, capsys):
             "capability_status": {
                 "main_search": {"ok": True, "configured": ["openai-compatible"], "fallback_chain": ["xai-responses", "openai-compatible"]},
                 "docs_search": {"ok": True, "configured": ["context7"], "fallback_chain": ["context7", "exa"]},
-                "web_fetch": {"ok": True, "configured": ["tavily"], "fallback_chain": ["tavily", "firecrawl"]},
+                "web_fetch": {"ok": True, "configured": ["tavily", "jina"], "fallback_chain": ["tavily", "jina", "zhipu-mcp-reader", "firecrawl"]},
             },
             "main_search_connection_tests": {
                 "openai-compatible": {
@@ -370,8 +380,10 @@ def test_doctor_markdown_outputs_human_health_report(monkeypatch, capsys):
             },
             "exa_connection_test": {"status": "ok", "message": "Exa ok", "response_time_ms": 11.1},
             "tavily_connection_test": {"status": "ok", "message": "Tavily ok", "response_time_ms": 22.2},
+            "jina_connection_test": {"status": "ok", "message": "Jina ok", "response_time_ms": 10.0},
             "firecrawl_connection_test": {"status": "configured", "message": "key configured"},
             "zhipu_connection_test": {"status": "warning", "message": "HTTP 429"},
+            "zhipu_mcp_connection_test": {"status": "not_configured", "message": "missing"},
             "context7_connection_test": {"status": "not_configured", "message": "missing"},
         }
 
@@ -989,6 +1001,12 @@ def test_provider_markdown_outputs_result_lists(monkeypatch, capsys):
     async def fake_zhipu_search(*args, **kwargs):
         return {"ok": True, "query": "news", "provider": "zhipu", "results": [{"title": "News", "url": "https://news.example.com", "description": "desc"}]}
 
+    async def fake_zhipu_mcp_search(*args, **kwargs):
+        return {"ok": True, "query": "news", "provider": "zhipu-mcp", "tool": "webSearchPrime", "results": [{"title": "MCP News", "url": "https://mcp.example.com"}]}
+
+    async def fake_zhipu_mcp_reader(*args, **kwargs):
+        return {"ok": True, "url": "https://source.example.com", "provider": "zhipu-mcp-reader", "tool": "webReader", "content": "# MCP Page"}
+
     async def fake_context7_library(*args, **kwargs):
         return {"ok": True, "query": "react", "provider": "context7", "results": [{"id": "/facebook/react", "title": "React", "description": "docs"}]}
 
@@ -998,6 +1016,8 @@ def test_provider_markdown_outputs_result_lists(monkeypatch, capsys):
     monkeypatch.setattr(cli.service, "exa_search", fake_exa_search)
     monkeypatch.setattr(cli.service, "exa_find_similar", fake_exa_similar)
     monkeypatch.setattr(cli.service, "zhipu_search", fake_zhipu_search)
+    monkeypatch.setattr(cli.service, "zhipu_mcp_search", fake_zhipu_mcp_search)
+    monkeypatch.setattr(cli.service, "zhipu_mcp_reader", fake_zhipu_mcp_reader)
     monkeypatch.setattr(cli.service, "context7_library", fake_context7_library)
     monkeypatch.setattr(cli.service, "map_site", fake_map_site)
 
@@ -1005,6 +1025,8 @@ def test_provider_markdown_outputs_result_lists(monkeypatch, capsys):
         (["exa-search", "query", "--format", "markdown"], "Example", "https://example.com"),
         (["exa-similar", "https://source.example.com", "--format", "markdown"], "Similar", "https://similar.example.com"),
         (["zhipu-search", "news", "--format", "markdown"], "News", "https://news.example.com"),
+        (["zhipu-mcp-search", "news", "--format", "markdown"], "MCP News", "https://mcp.example.com"),
+        (["zhipu-mcp-reader", "https://source.example.com", "--format", "markdown"], "MCP Page", "Zhipu Coding Plan MCP Reader"),
         (["context7-library", "react", "--format", "markdown"], "React", "/facebook/react"),
         (["map", "https://docs.example.com", "--format", "markdown"], "https://docs.example.com/api", "Site Map"),
     ]
@@ -1059,6 +1081,12 @@ def test_all_formatted_commands_have_non_json_markdown(monkeypatch):
     async def fake_zhipu(*args, **kwargs):
         return {"ok": True, "results": [{"title": "News", "url": "https://news.example.com"}]}
 
+    async def fake_zhipu_mcp(*args, **kwargs):
+        return {"ok": True, "provider": "zhipu-mcp", "tool": "webSearchPrime", "results": [{"title": "MCP", "url": "https://mcp.example.com"}]}
+
+    async def fake_zhipu_mcp_reader(*args, **kwargs):
+        return {"ok": True, "provider": "zhipu-mcp-reader", "tool": "webReader", "content": "MCP Page"}
+
     async def fake_c7_library(*args, **kwargs):
         return {"ok": True, "results": [{"id": "/lib", "title": "Library"}]}
 
@@ -1098,6 +1126,11 @@ def test_all_formatted_commands_have_non_json_markdown(monkeypatch):
     monkeypatch.setattr(cli.service, "exa_search", fake_exa)
     monkeypatch.setattr(cli.service, "exa_find_similar", fake_exa)
     monkeypatch.setattr(cli.service, "zhipu_search", fake_zhipu)
+    monkeypatch.setattr(cli.service, "zhipu_mcp_search", fake_zhipu_mcp)
+    monkeypatch.setattr(cli.service, "zhipu_mcp_reader", fake_zhipu_mcp_reader)
+    monkeypatch.setattr(cli.service, "zhipu_mcp_search_doc", fake_zhipu_mcp)
+    monkeypatch.setattr(cli.service, "zhipu_mcp_repo_structure", fake_zhipu_mcp)
+    monkeypatch.setattr(cli.service, "zhipu_mcp_read_file", fake_zhipu_mcp)
     monkeypatch.setattr(cli.service, "context7_library", fake_c7_library)
     monkeypatch.setattr(cli.service, "context7_docs", fake_c7_docs)
     monkeypatch.setattr(cli.service, "doctor", fake_doctor)
@@ -1117,6 +1150,11 @@ def test_all_formatted_commands_have_non_json_markdown(monkeypatch):
         ("exa-search", ["exa-search", "query", "--format", "markdown"]),
         ("exa-similar", ["exa-similar", "https://example.com", "--format", "markdown"]),
         ("zhipu-search", ["zhipu-search", "query", "--format", "markdown"]),
+        ("zhipu-mcp-search", ["zhipu-mcp-search", "query", "--format", "markdown"]),
+        ("zhipu-mcp-reader", ["zhipu-mcp-reader", "https://example.com", "--format", "markdown"]),
+        ("zhipu-mcp-search-doc", ["zhipu-mcp-search-doc", "owner/repo", "install", "--format", "markdown"]),
+        ("zhipu-mcp-repo-structure", ["zhipu-mcp-repo-structure", "owner/repo", "--format", "markdown"]),
+        ("zhipu-mcp-read-file", ["zhipu-mcp-read-file", "owner/repo", "README.md", "--format", "markdown"]),
         ("context7-library", ["context7-library", "react", "--format", "markdown"]),
         ("context7-docs", ["context7-docs", "/lib", "hooks", "--format", "markdown"]),
         ("deep", ["deep", "query", "--format", "markdown"]),
@@ -1141,6 +1179,11 @@ def test_all_formatted_commands_have_non_json_markdown(monkeypatch):
             "exa-search": {"ok": True, "results": [{"title": "Example", "url": "https://example.com"}]},
             "exa-similar": {"ok": True, "results": [{"title": "Example", "url": "https://example.com"}]},
             "zhipu-search": {"ok": True, "results": [{"title": "News", "url": "https://news.example.com"}]},
+            "zhipu-mcp-search": {"ok": True, "provider": "zhipu-mcp", "tool": "webSearchPrime", "results": [{"title": "MCP", "url": "https://mcp.example.com"}]},
+            "zhipu-mcp-reader": {"ok": True, "provider": "zhipu-mcp-reader", "tool": "webReader", "content": "MCP Page"},
+            "zhipu-mcp-search-doc": {"ok": True, "provider": "zhipu-mcp-zread", "tool": "search_doc", "results": [{"title": "Doc", "url": "https://docs.example.com"}]},
+            "zhipu-mcp-repo-structure": {"ok": True, "provider": "zhipu-mcp-zread", "tool": "get_repo_structure", "content": "tree"},
+            "zhipu-mcp-read-file": {"ok": True, "provider": "zhipu-mcp-zread", "tool": "read_file", "content": "file"},
             "context7-library": {"ok": True, "results": [{"id": "/lib", "title": "Library"}]},
             "context7-docs": {"ok": True, "library_id": "/lib", "query": "hooks", "content": "Docs"},
             "deep": {"ok": True, "mode": "deep_research", "question": "q", "difficulty": "standard", "evidence_policy": "fetch_before_claim"},
@@ -1255,6 +1298,24 @@ def test_setup_non_interactive_saves_values(monkeypatch, capsys):
         "zhipu.example.com/api",
         "--zhipu-search-engine",
         "search_pro",
+        "--zhipu-mcp-key",
+        "zmcp-secret",
+        "--zhipu-mcp-search-api-url",
+        "https://zmcp.example.com/search",
+        "--zhipu-mcp-reader-api-url",
+        "https://zmcp.example.com/reader",
+        "--zhipu-mcp-zread-api-url",
+        "https://zmcp.example.com/zread",
+        "--zhipu-mcp-timeout",
+        "8",
+        "--jina-key",
+        "jina-secret",
+        "--jina-reader-api-url",
+        "r.jina.ai",
+        "--jina-respond-with",
+        "readerlm-v2",
+        "--jina-timeout",
+        "10",
         "--context7-key",
         "ctx-secret",
         "--tavily-api-url",
@@ -1288,6 +1349,15 @@ def test_setup_non_interactive_saves_values(monkeypatch, capsys):
     assert saved["ZHIPU_API_KEY"] == "zhipu-secret"
     assert saved["ZHIPU_API_URL"] == "https://zhipu.example.com/api"
     assert saved["ZHIPU_SEARCH_ENGINE"] == "search_pro"
+    assert saved["ZHIPU_MCP_API_KEY"] == "zmcp-secret"
+    assert saved["ZHIPU_MCP_SEARCH_API_URL"] == "https://zmcp.example.com/search"
+    assert saved["ZHIPU_MCP_READER_API_URL"] == "https://zmcp.example.com/reader"
+    assert saved["ZHIPU_MCP_ZREAD_API_URL"] == "https://zmcp.example.com/zread"
+    assert saved["ZHIPU_MCP_TIMEOUT_SECONDS"] == "8"
+    assert saved["JINA_API_KEY"] == "jina-secret"
+    assert saved["JINA_READER_API_URL"] == "https://r.jina.ai"
+    assert saved["JINA_RESPOND_WITH"] == "readerlm-v2"
+    assert saved["JINA_TIMEOUT_SECONDS"] == "10"
     assert saved["CONTEXT7_API_KEY"] == "ctx-secret"
     assert saved["TAVILY_API_URL"] == "https://pool.example.com/api/tavily"
     assert saved["TAVILY_API_KEY"] == "th-test-secret"
@@ -1298,6 +1368,8 @@ def test_setup_non_interactive_saves_values(monkeypatch, capsys):
     assert saved["ANYSEARCH_TIMEOUT_SECONDS"] == "9"
     assert "xai-test-secret" not in out
     assert "th-test-secret" not in out
+    assert "jina-secret" not in out
+    assert "zmcp-secret" not in out
     assert "as-test-secret" not in out
 
 
@@ -1892,6 +1964,55 @@ def test_anysearch_commands_use_service_wrappers(monkeypatch, capsys):
         ("search", "CVE-2024-3094", "security.cve", "xz", 2),
         ("extract", "https://example.com", 123),
         ("batch", ["a", "b"], 1),
+    ]
+
+
+def test_zhipu_mcp_commands_use_service_wrappers(monkeypatch, capsys):
+    calls = []
+
+    async def fake_search(query, count=5):
+        calls.append(("search", query, count))
+        return {"ok": True, "provider": "zhipu-mcp", "tool": "webSearchPrime", "results": []}
+
+    async def fake_reader(url):
+        calls.append(("reader", url))
+        return {"ok": True, "provider": "zhipu-mcp-reader", "tool": "webReader", "content": "# Page"}
+
+    async def fake_search_doc(repo, query, max_results=5):
+        calls.append(("search_doc", repo, query, max_results))
+        return {"ok": True, "provider": "zhipu-mcp-zread", "tool": "search_doc", "results": []}
+
+    async def fake_repo_structure(repo, ref=""):
+        calls.append(("repo_structure", repo, ref))
+        return {"ok": True, "provider": "zhipu-mcp-zread", "tool": "get_repo_structure", "content": "tree"}
+
+    async def fake_read_file(repo, path, ref=""):
+        calls.append(("read_file", repo, path, ref))
+        return {"ok": True, "provider": "zhipu-mcp-zread", "tool": "read_file", "content": "file"}
+
+    monkeypatch.setattr(cli.service, "zhipu_mcp_search", fake_search)
+    monkeypatch.setattr(cli.service, "zhipu_mcp_reader", fake_reader)
+    monkeypatch.setattr(cli.service, "zhipu_mcp_search_doc", fake_search_doc)
+    monkeypatch.setattr(cli.service, "zhipu_mcp_repo_structure", fake_repo_structure)
+    monkeypatch.setattr(cli.service, "zhipu_mcp_read_file", fake_read_file)
+
+    assert cli.main(["zhipu-mcp-search", "news", "--count", "2"]) == cli.EXIT_OK
+    assert json.loads(capsys.readouterr().out)["tool"] == "webSearchPrime"
+    assert cli.main(["zmcp-reader", "https://example.com"]) == cli.EXIT_OK
+    assert json.loads(capsys.readouterr().out)["tool"] == "webReader"
+    assert cli.main(["zmcp-doc", "owner/repo", "install", "--max-results", "3"]) == cli.EXIT_OK
+    assert json.loads(capsys.readouterr().out)["tool"] == "search_doc"
+    assert cli.main(["zmcp-tree", "owner/repo", "--ref", "main"]) == cli.EXIT_OK
+    assert json.loads(capsys.readouterr().out)["tool"] == "get_repo_structure"
+    assert cli.main(["zmcp-file", "owner/repo", "README.md", "--ref", "main"]) == cli.EXIT_OK
+    assert json.loads(capsys.readouterr().out)["tool"] == "read_file"
+
+    assert calls == [
+        ("search", "news", 2),
+        ("reader", "https://example.com"),
+        ("search_doc", "owner/repo", "install", 3),
+        ("repo_structure", "owner/repo", "main"),
+        ("read_file", "owner/repo", "README.md", "main"),
     ]
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -557,6 +557,77 @@ def test_deep_alias_and_markdown_output(monkeypatch, capsys):
     assert "smart-search fetch" in out
 
 
+def test_research_command_uses_service_and_outputs_json(monkeypatch, capsys, tmp_path):
+    captured = {}
+
+    async def fake_research(query, budget="deep", evidence_dir="", fallback="auto"):
+        captured.update({"query": query, "budget": budget, "evidence_dir": evidence_dir, "fallback": fallback})
+        return {
+            "ok": True,
+            "mode": "deep_research_execution",
+            "query_mode": "research",
+            "question": query,
+            "final_answer": "Evidence answer",
+            "content": "Evidence answer",
+            "citations": [{"url": "https://example.com", "title": "Example", "provider": "jina"}],
+            "evidence_items": [{"url": "https://example.com", "provider": "jina", "content": "Evidence"}],
+            "gap_check": {"status": "closed", "gaps": []},
+            "provider_attempts": [],
+            "fallback_used": False,
+            "degraded": False,
+            "route_policy_version": "research-router-v1",
+            "evidence_dir": evidence_dir,
+        }
+
+    monkeypatch.setattr(cli.service, "research", fake_research)
+
+    code = cli.main([
+        "research",
+        "React docs",
+        "--budget",
+        "standard",
+        "--evidence-dir",
+        str(tmp_path),
+        "--fallback",
+        "off",
+        "--format",
+        "json",
+    ])
+
+    assert code == cli.EXIT_OK
+    data = json.loads(capsys.readouterr().out)
+    assert captured == {"query": "React docs", "budget": "standard", "evidence_dir": str(tmp_path), "fallback": "off"}
+    assert data["query_mode"] == "research"
+    assert data["final_answer"] == "Evidence answer"
+
+
+def test_research_markdown_and_content_output(monkeypatch, capsys):
+    async def fake_research(query, budget="deep", evidence_dir="", fallback="auto"):
+        return {
+            "ok": True,
+            "question": query,
+            "final_answer": "Evidence answer",
+            "content": "Evidence answer",
+            "citations": [{"url": "https://example.com", "title": "Example", "provider": "jina"}],
+            "gap_check": {"gaps": []},
+            "fallback_used": True,
+            "degraded": False,
+            "route_policy_version": "research-router-v1",
+            "evidence_dir": "C:/tmp/evidence",
+        }
+
+    monkeypatch.setattr(cli.service, "research", fake_research)
+
+    assert cli.main(["rs", "React docs", "--format", "markdown"]) == cli.EXIT_OK
+    markdown = capsys.readouterr().out
+    assert "# Research Report" in markdown
+    assert "Evidence answer" in markdown
+    assert "https://example.com" in markdown
+
+    assert cli.main(["research", "React docs", "--format", "content"]) == cli.EXIT_OK
+    assert capsys.readouterr().out == "Evidence answer\n"
+
+
 def test_exa_search_passes_powershell_split_domains(monkeypatch, capsys):
     captured = {}
 
@@ -1099,6 +1170,9 @@ def test_all_formatted_commands_have_non_json_markdown(monkeypatch):
     async def fake_smoke(mode="mock"):
         return {"ok": True, "mode": mode, "failed_cases": [], "cases": [{"name": "case", "ok": True}]}
 
+    async def fake_research(query, budget="deep", evidence_dir="", fallback="auto"):
+        return {"ok": True, "question": query, "content": "Research", "final_answer": "Research", "citations": [], "gap_check": {"gaps": []}}
+
     def fake_plan(*args, **kwargs):
         return {"ok": True, "mode": "deep_research", "question": "q", "difficulty": "standard", "evidence_policy": "fetch_before_claim"}
 
@@ -1135,6 +1209,7 @@ def test_all_formatted_commands_have_non_json_markdown(monkeypatch):
     monkeypatch.setattr(cli.service, "context7_docs", fake_c7_docs)
     monkeypatch.setattr(cli.service, "doctor", fake_doctor)
     monkeypatch.setattr(cli.service, "smoke", fake_smoke)
+    monkeypatch.setattr(cli.service, "research", fake_research)
     monkeypatch.setattr(cli.service, "build_deep_research_plan", fake_plan)
     monkeypatch.setattr(cli.service, "config_path", fake_config_path)
     monkeypatch.setattr(cli.service, "config_list", fake_config_list)
@@ -1158,6 +1233,7 @@ def test_all_formatted_commands_have_non_json_markdown(monkeypatch):
         ("context7-library", ["context7-library", "react", "--format", "markdown"]),
         ("context7-docs", ["context7-docs", "/lib", "hooks", "--format", "markdown"]),
         ("deep", ["deep", "query", "--format", "markdown"]),
+        ("research", ["research", "query", "--format", "markdown"]),
         ("smoke", ["smoke", "--format", "markdown"]),
         ("doctor", ["doctor", "--format", "markdown"]),
         ("diagnose", ["diagnose", "openai-compatible", "--format", "markdown"]),
@@ -1187,6 +1263,7 @@ def test_all_formatted_commands_have_non_json_markdown(monkeypatch):
             "context7-library": {"ok": True, "results": [{"id": "/lib", "title": "Library"}]},
             "context7-docs": {"ok": True, "library_id": "/lib", "query": "hooks", "content": "Docs"},
             "deep": {"ok": True, "mode": "deep_research", "question": "q", "difficulty": "standard", "evidence_policy": "fetch_before_claim"},
+            "research": {"ok": True, "question": "q", "content": "Research", "final_answer": "Research", "citations": [], "gap_check": {"gaps": []}},
             "smoke": {"ok": True, "mode": "mock", "failed_cases": [], "cases": [{"name": "case", "ok": True}]},
             "doctor": {"ok": True, "config_status": "ok", "minimum_profile_ok": True},
             "diagnose": {"ok": True, "provider": "openai-compatible", "summary": "ok", "recommendation": "none"},
@@ -1918,6 +1995,9 @@ def test_smoke_command_uses_service(monkeypatch, capsys):
     async def fake_smoke(mode="mock"):
         return {"ok": True, "mode": mode, "failed_cases": [], "cases": []}
 
+    async def fake_research(*args, **kwargs):
+        return {"ok": True, "query_mode": "research", "content": "Research"}
+
     monkeypatch.setattr(cli.service, "smoke", fake_smoke)
 
     code = cli.main(["smoke", "--mode", "mock"])
@@ -2044,6 +2124,9 @@ def test_provider_and_smoke_aliases_use_canonical_commands(monkeypatch, capsys):
     async def fake_smoke(mode="mock"):
         return {"ok": True, "mode": mode, "failed_cases": [], "cases": []}
 
+    async def fake_research(*args, **kwargs):
+        return {"ok": True, "query_mode": "research", "content": "Research"}
+
     monkeypatch.setattr(cli.service, "exa_search", fake_exa_search)
     monkeypatch.setattr(cli.service, "zhipu_search", fake_zhipu_search)
     monkeypatch.setattr(cli.service, "context7_library", fake_context7_library)
@@ -2053,6 +2136,7 @@ def test_provider_and_smoke_aliases_use_canonical_commands(monkeypatch, capsys):
     monkeypatch.setattr(cli.service, "anysearch_extract", fake_anysearch_extract)
     monkeypatch.setattr(cli.service, "anysearch_batch", fake_anysearch_batch)
     monkeypatch.setattr(cli.service, "smoke", fake_smoke)
+    monkeypatch.setattr(cli.service, "research", fake_research)
 
     assert cli.main(["exa", "query"]) == cli.EXIT_OK
     assert json.loads(capsys.readouterr().out)["provider"] == "exa"
@@ -2070,6 +2154,8 @@ def test_provider_and_smoke_aliases_use_canonical_commands(monkeypatch, capsys):
     assert json.loads(capsys.readouterr().out)["provider"] == "context7-library"
     assert cli.main(["c7docs", "/facebook/react", "hooks"]) == cli.EXIT_OK
     assert json.loads(capsys.readouterr().out)["provider"] == "context7-docs"
+    assert cli.main(["rs", "query"]) == cli.EXIT_OK
+    assert json.loads(capsys.readouterr().out)["query_mode"] == "research"
     assert cli.main(["sm"]) == cli.EXIT_OK
     assert json.loads(capsys.readouterr().out)["mode"] == "mock"
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1073,7 +1073,7 @@ def test_provider_markdown_outputs_result_lists(monkeypatch, capsys):
         return {"ok": True, "query": "news", "provider": "zhipu", "results": [{"title": "News", "url": "https://news.example.com", "description": "desc"}]}
 
     async def fake_zhipu_mcp_search(*args, **kwargs):
-        return {"ok": True, "query": "news", "provider": "zhipu-mcp", "tool": "webSearchPrime", "results": [{"title": "MCP News", "url": "https://mcp.example.com"}]}
+        return {"ok": True, "query": "news", "provider": "zhipu-mcp", "tool": "web_search_prime", "results": [{"title": "MCP News", "url": "https://mcp.example.com"}]}
 
     async def fake_zhipu_mcp_reader(*args, **kwargs):
         return {"ok": True, "url": "https://source.example.com", "provider": "zhipu-mcp-reader", "tool": "webReader", "content": "# MCP Page"}
@@ -1153,7 +1153,7 @@ def test_all_formatted_commands_have_non_json_markdown(monkeypatch):
         return {"ok": True, "results": [{"title": "News", "url": "https://news.example.com"}]}
 
     async def fake_zhipu_mcp(*args, **kwargs):
-        return {"ok": True, "provider": "zhipu-mcp", "tool": "webSearchPrime", "results": [{"title": "MCP", "url": "https://mcp.example.com"}]}
+        return {"ok": True, "provider": "zhipu-mcp", "tool": "web_search_prime", "results": [{"title": "MCP", "url": "https://mcp.example.com"}]}
 
     async def fake_zhipu_mcp_reader(*args, **kwargs):
         return {"ok": True, "provider": "zhipu-mcp-reader", "tool": "webReader", "content": "MCP Page"}
@@ -1255,7 +1255,7 @@ def test_all_formatted_commands_have_non_json_markdown(monkeypatch):
             "exa-search": {"ok": True, "results": [{"title": "Example", "url": "https://example.com"}]},
             "exa-similar": {"ok": True, "results": [{"title": "Example", "url": "https://example.com"}]},
             "zhipu-search": {"ok": True, "results": [{"title": "News", "url": "https://news.example.com"}]},
-            "zhipu-mcp-search": {"ok": True, "provider": "zhipu-mcp", "tool": "webSearchPrime", "results": [{"title": "MCP", "url": "https://mcp.example.com"}]},
+            "zhipu-mcp-search": {"ok": True, "provider": "zhipu-mcp", "tool": "web_search_prime", "results": [{"title": "MCP", "url": "https://mcp.example.com"}]},
             "zhipu-mcp-reader": {"ok": True, "provider": "zhipu-mcp-reader", "tool": "webReader", "content": "MCP Page"},
             "zhipu-mcp-search-doc": {"ok": True, "provider": "zhipu-mcp-zread", "tool": "search_doc", "results": [{"title": "Doc", "url": "https://docs.example.com"}]},
             "zhipu-mcp-repo-structure": {"ok": True, "provider": "zhipu-mcp-zread", "tool": "get_repo_structure", "content": "tree"},
@@ -2052,7 +2052,7 @@ def test_zhipu_mcp_commands_use_service_wrappers(monkeypatch, capsys):
 
     async def fake_search(query, count=5):
         calls.append(("search", query, count))
-        return {"ok": True, "provider": "zhipu-mcp", "tool": "webSearchPrime", "results": []}
+        return {"ok": True, "provider": "zhipu-mcp", "tool": "web_search_prime", "results": []}
 
     async def fake_reader(url):
         calls.append(("reader", url))
@@ -2077,7 +2077,7 @@ def test_zhipu_mcp_commands_use_service_wrappers(monkeypatch, capsys):
     monkeypatch.setattr(cli.service, "zhipu_mcp_read_file", fake_read_file)
 
     assert cli.main(["zhipu-mcp-search", "news", "--count", "2"]) == cli.EXIT_OK
-    assert json.loads(capsys.readouterr().out)["tool"] == "webSearchPrime"
+    assert json.loads(capsys.readouterr().out)["tool"] == "web_search_prime"
     assert cli.main(["zmcp-reader", "https://example.com"]) == cli.EXIT_OK
     assert json.loads(capsys.readouterr().out)["tool"] == "webReader"
     assert cli.main(["zmcp-doc", "owner/repo", "install", "--max-results", "3"]) == cli.EXIT_OK

--- a/tests/test_jina_provider.py
+++ b/tests/test_jina_provider.py
@@ -1,0 +1,139 @@
+import json
+
+import httpx
+import pytest
+
+from smart_search.providers.jina import JinaReaderProvider
+
+
+class FakeJinaClient:
+    calls = []
+    response: httpx.Response | None = None
+    exception: Exception | None = None
+
+    def __init__(self, timeout, follow_redirects=True):
+        self.timeout = timeout
+        self.follow_redirects = follow_redirects
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return None
+
+    async def get(self, url, headers):
+        self.__class__.calls.append({"url": url, "headers": headers, "timeout": self.timeout})
+        if self.__class__.exception:
+            raise self.__class__.exception
+        return self.__class__.response
+
+
+@pytest.fixture(autouse=True)
+def reset_fake_client():
+    FakeJinaClient.calls = []
+    FakeJinaClient.response = None
+    FakeJinaClient.exception = None
+
+
+@pytest.mark.asyncio
+async def test_jina_reader_fetch_sends_auth_and_markdown_header(monkeypatch):
+    FakeJinaClient.response = httpx.Response(
+        200,
+        text="Title: Example\n\nExample content.",
+        request=httpx.Request("GET", "https://r.jina.ai/https://example.com"),
+    )
+    monkeypatch.setattr("smart_search.providers.jina.httpx.AsyncClient", FakeJinaClient)
+
+    provider = JinaReaderProvider("https://r.jina.ai", "jina-secret", timeout=12)
+    data = json.loads(await provider.fetch("https://example.com"))
+
+    assert data["ok"] is True
+    assert data["provider"] == "jina"
+    assert data["content"].startswith("Title: Example")
+    call = FakeJinaClient.calls[0]
+    assert call["url"] == "https://r.jina.ai/https://example.com"
+    assert call["headers"]["Authorization"] == "Bearer jina-secret"
+    assert call["headers"]["X-Return-Format"] == "markdown"
+    assert call["timeout"].read == 12.0
+
+
+@pytest.mark.asyncio
+async def test_jina_reader_rejects_readerlm_without_key_before_network(monkeypatch):
+    monkeypatch.setattr("smart_search.providers.jina.httpx.AsyncClient", FakeJinaClient)
+
+    provider = JinaReaderProvider("https://r.jina.ai", None, respond_with="readerlm-v2")
+    data = json.loads(await provider.fetch("https://example.com"))
+
+    assert data["ok"] is False
+    assert data["error_type"] == "config_error"
+    assert FakeJinaClient.calls == []
+
+
+@pytest.mark.asyncio
+async def test_jina_reader_challenge_page_is_quality_error(monkeypatch):
+    FakeJinaClient.response = httpx.Response(
+        200,
+        text="Title: Just a moment...\n\nChecking if the site connection is secure.",
+        request=httpx.Request("GET", "https://r.jina.ai/https://blocked.example.com"),
+    )
+    monkeypatch.setattr("smart_search.providers.jina.httpx.AsyncClient", FakeJinaClient)
+
+    provider = JinaReaderProvider("https://r.jina.ai", "jina-secret")
+    data = json.loads(await provider.fetch("https://blocked.example.com"))
+
+    assert data["ok"] is False
+    assert data["error_type"] == "quality_error"
+    assert "challenge" in data["error"]
+
+
+@pytest.mark.asyncio
+async def test_jina_reader_http_422_is_parameter_error(monkeypatch):
+    FakeJinaClient.response = httpx.Response(
+        422,
+        text="bad url",
+        request=httpx.Request("GET", "https://r.jina.ai/bad"),
+    )
+    monkeypatch.setattr("smart_search.providers.jina.httpx.AsyncClient", FakeJinaClient)
+
+    provider = JinaReaderProvider("https://r.jina.ai", "jina-secret")
+    data = json.loads(await provider.fetch("bad"))
+
+    assert data["ok"] is False
+    assert data["error_type"] == "parameter_error"
+    assert "HTTP 422" in data["error"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("status_code", "expected_error_type"),
+    [
+        (401, "auth_error"),
+        (429, "rate_limited"),
+    ],
+)
+async def test_jina_reader_http_status_error_types(monkeypatch, status_code, expected_error_type):
+    FakeJinaClient.response = httpx.Response(
+        status_code,
+        text="provider error",
+        request=httpx.Request("GET", "https://r.jina.ai/https://example.com"),
+    )
+    monkeypatch.setattr("smart_search.providers.jina.httpx.AsyncClient", FakeJinaClient)
+
+    provider = JinaReaderProvider("https://r.jina.ai", "jina-secret")
+    data = json.loads(await provider.fetch("https://example.com"))
+
+    assert data["ok"] is False
+    assert data["error_type"] == expected_error_type
+    assert f"HTTP {status_code}" in data["error"]
+
+
+@pytest.mark.asyncio
+async def test_jina_reader_timeout_is_timeout_error(monkeypatch):
+    FakeJinaClient.exception = httpx.TimeoutException("slow")
+    monkeypatch.setattr("smart_search.providers.jina.httpx.AsyncClient", FakeJinaClient)
+
+    provider = JinaReaderProvider("https://r.jina.ai", "jina-secret")
+    data = json.loads(await provider.fetch("https://example.com"))
+
+    assert data["ok"] is False
+    assert data["error_type"] == "timeout"

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -300,6 +300,61 @@ def test_zhipu_setup_contract_public_and_packaged_assets_match():
         assert marker in packaged_contract
 
 
+def test_jina_and_zhipu_mcp_contract_public_and_packaged_assets_match():
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    readme_zh = (ROOT / "README.zh-CN.md").read_text(encoding="utf-8")
+    public_text = _read_skill_tree(PUBLIC_SKILL_DIR)
+    packaged_text = _read_skill_tree(PACKAGED_SKILL_DIR)
+    public_contract = (PUBLIC_SKILL_DIR / "references" / "cli-contract.md").read_text(encoding="utf-8")
+    packaged_contract = (PACKAGED_SKILL_DIR / "references" / "cli-contract.md").read_text(encoding="utf-8")
+
+    required_markers = [
+        "JINA_API_KEY",
+        "JINA_READER_API_URL",
+        "JINA_RESPOND_WITH",
+        "Jina Reader is `web_fetch` only",
+        "Anonymous Jina Reader calls",
+        "ZHIPU_MCP_API_KEY",
+        "ZHIPU_MCP_SEARCH_API_URL",
+        "ZHIPU_MCP_READER_API_URL",
+        "ZHIPU_MCP_ZREAD_API_URL",
+        "webSearchPrime",
+        "webReader",
+        "search_doc",
+        "get_repo_structure",
+        "read_file",
+        "Remote MCP",
+        "Do not route it through the existing `/paas/v4/web_search`",
+    ]
+    for marker in required_markers:
+        assert marker in public_text
+        assert marker in packaged_text
+        assert marker in public_contract
+        assert marker in packaged_contract
+
+    readme_markers = [
+        "JINA_API_KEY",
+        "Zhipu Coding Plan Remote MCP",
+        "zhipu-mcp-search",
+        "zhipu-mcp-reader",
+        "not mixed into the existing `/paas/v4/web_search`",
+        "Jina Reader is not a general search provider",
+    ]
+    for marker in readme_markers:
+        assert marker in readme
+
+    zh_markers = [
+        "JINA_API_KEY",
+        "智谱 Coding Plan Remote MCP",
+        "zhipu-mcp-search",
+        "zhipu-mcp-reader",
+        "不会混进现有 `/paas/v4/web_search`",
+        "Jina Reader 不是通用搜索 provider",
+    ]
+    for marker in zh_markers:
+        assert marker in readme_zh
+
+
 def test_streaming_and_anysearch_contract_public_and_packaged_assets_match():
     readme = (ROOT / "README.md").read_text(encoding="utf-8")
     readme_zh = (ROOT / "README.zh-CN.md").read_text(encoding="utf-8")

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -337,6 +337,8 @@ def test_jina_and_zhipu_mcp_contract_public_and_packaged_assets_match():
         "read_file",
         "Remote MCP",
         "Do not route it through the existing `/paas/v4/web_search`",
+        "Coding Plan entitlement",
+        "does not affect the standard minimum profile",
     ]
     for marker in required_markers:
         assert marker in public_text
@@ -351,6 +353,7 @@ def test_jina_and_zhipu_mcp_contract_public_and_packaged_assets_match():
         "zhipu-mcp-reader",
         "not mixed into the existing `/paas/v4/web_search`",
         "Jina Reader is not a general search provider",
+        "A normal `ZHIPU_API_KEY` for Web Search API does not prove `zhipu-mcp-search` or zread access",
     ]
     for marker in readme_markers:
         assert marker in readme
@@ -362,6 +365,7 @@ def test_jina_and_zhipu_mcp_contract_public_and_packaged_assets_match():
         "zhipu-mcp-reader",
         "不会混进现有 `/paas/v4/web_search`",
         "Jina Reader 不是通用搜索 provider",
+        "普通 `ZHIPU_API_KEY` 能用 Web Search API，不代表能用 `zhipu-mcp-search` 或 zread",
     ]
     for marker in zh_markers:
         assert marker in readme_zh

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -330,7 +330,7 @@ def test_jina_and_zhipu_mcp_contract_public_and_packaged_assets_match():
         "ZHIPU_MCP_SEARCH_API_URL",
         "ZHIPU_MCP_READER_API_URL",
         "ZHIPU_MCP_ZREAD_API_URL",
-        "webSearchPrime",
+        "web_search_prime",
         "webReader",
         "search_doc",
         "get_repo_structure",

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -82,9 +82,12 @@ def test_deep_research_skill_contract_public_and_packaged_assets_match():
         "C:\\tmp\\smart-search-evidence",
         "mock-full plus live-limited",
         "public planner entrypoint",
+        "public live executor entrypoint",
         "not an executor",
         "does not change default `smart-search search`",
         "does not depend on an MCP session",
+        "SMART_SEARCH_RESEARCH_PREFERRED_PROVIDERS",
+        "provider advantage routing",
     ]
     for marker in required_markers:
         assert marker in public_text
@@ -97,6 +100,7 @@ def test_deep_research_cli_contract_documents_plan_and_smoke_matrix():
     required_markers = [
         "Deep Research Skill Contract",
         "`smart-search deep` is the public offline planner command",
+        "`smart-search research` is the public live executor command",
         "must not change default `smart-search search` behavior",
         "`mode`: always `deep_research`",
         "`query_mode`: always `deep`",
@@ -117,6 +121,8 @@ def test_deep_research_cli_contract_documents_plan_and_smoke_matrix():
         "must not require fixed topic recipe ids",
         "fixed topic recipe ids are not required schema",
         "Mock-full coverage should cover trigger phrases",
+        "research provider advantage routing",
+        "`research --fallback auto` permits same-capability fallback",
         "Live-limited coverage should run `doctor`, one broad `search`, one `exa-search`, and one `fetch`",
         "`smart-search skills status --targets codex,claude,cursor,hermes --format json`",
         "`smart-search skills update --targets codex,claude,cursor,hermes --format json`",
@@ -176,6 +182,9 @@ def test_deep_research_readme_documents_capability_orchestration():
     readme_zh = (ROOT / "README.zh-CN.md").read_text(encoding="utf-8")
     english_markers = [
         "Deep Research is not a fixed topic recipe system",
+        "smart-search research",
+        "`route_policy_version`",
+        "provider-advantage",
         "`intent_signals`",
         "`decomposition`",
         "`capability_plan`",
@@ -191,6 +200,9 @@ def test_deep_research_readme_documents_capability_orchestration():
     ]
     chinese_markers = [
         "Deep Research 不是固定题材配方",
+        "smart-search research",
+        "`route_policy_version`",
+        "provider 优势",
         "`intent_signals`",
         "`decomposition`",
         "`capability_plan`",

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -28,6 +28,15 @@ def _reset_config(monkeypatch, tmp_path):
         "ZHIPU_API_URL",
         "ZHIPU_SEARCH_ENGINE",
         "ZHIPU_TIMEOUT_SECONDS",
+        "ZHIPU_MCP_API_KEY",
+        "ZHIPU_MCP_SEARCH_API_URL",
+        "ZHIPU_MCP_READER_API_URL",
+        "ZHIPU_MCP_ZREAD_API_URL",
+        "ZHIPU_MCP_TIMEOUT_SECONDS",
+        "JINA_API_KEY",
+        "JINA_READER_API_URL",
+        "JINA_RESPOND_WITH",
+        "JINA_TIMEOUT_SECONDS",
         "TAVILY_API_KEY",
         "TAVILY_API_URL",
         "FIRECRAWL_API_KEY",
@@ -118,6 +127,38 @@ def test_anysearch_config_defaults_and_saved_values(monkeypatch, tmp_path):
     assert service.config.anysearch_api_url == "https://anysearch.example.com/mcp"
     assert service.config.anysearch_api_key == "as-test-secret"
     assert service.config.anysearch_timeout == 9.0
+
+
+def test_jina_and_zhipu_mcp_config_defaults_and_saved_values(monkeypatch, tmp_path):
+    _reset_config(monkeypatch, tmp_path)
+
+    assert service.config.jina_reader_api_url == "https://r.jina.ai"
+    assert service.config.jina_api_key is None
+    assert service.config.jina_respond_with == ""
+    assert service.config.jina_timeout == 30.0
+    assert service.config.zhipu_mcp_search_api_url == "https://open.bigmodel.cn/api/mcp/web_search_prime/mcp"
+    assert service.config.zhipu_mcp_reader_api_url == "https://open.bigmodel.cn/api/mcp/web_reader/mcp"
+    assert service.config.zhipu_mcp_zread_api_url == "https://open.bigmodel.cn/api/mcp/zread/mcp"
+
+    service.config_set("JINA_API_KEY", "jina-test-secret")
+    service.config_set("JINA_READER_API_URL", "https://reader.example.com")
+    service.config_set("JINA_RESPOND_WITH", "readerlm-v2")
+    service.config_set("JINA_TIMEOUT_SECONDS", "11")
+    service.config_set("ZHIPU_MCP_API_KEY", "zmcp-test-secret")
+    service.config_set("ZHIPU_MCP_SEARCH_API_URL", "https://zmcp.example.com/search")
+    service.config_set("ZHIPU_MCP_READER_API_URL", "https://zmcp.example.com/reader")
+    service.config_set("ZHIPU_MCP_ZREAD_API_URL", "https://zmcp.example.com/zread")
+    service.config_set("ZHIPU_MCP_TIMEOUT_SECONDS", "12")
+
+    assert service.config.jina_api_key == "jina-test-secret"
+    assert service.config.jina_reader_api_url == "https://reader.example.com"
+    assert service.config.jina_respond_with == "readerlm-v2"
+    assert service.config.jina_timeout == 11.0
+    assert service.config.zhipu_mcp_api_key == "zmcp-test-secret"
+    assert service.config.zhipu_mcp_search_api_url == "https://zmcp.example.com/search"
+    assert service.config.zhipu_mcp_reader_api_url == "https://zmcp.example.com/reader"
+    assert service.config.zhipu_mcp_zread_api_url == "https://zmcp.example.com/zread"
+    assert service.config.zhipu_mcp_timeout == 12.0
 
 
 def test_environment_overrides_config_file(monkeypatch, tmp_path):
@@ -529,6 +570,86 @@ def test_anysearch_vertical_status_is_experimental_and_not_minimum_required(monk
     assert with_anysearch["capability_status"]["vertical_search"]["configured"] == ["anysearch"]
 
 
+def test_jina_key_satisfies_web_fetch_but_anonymous_jina_does_not(monkeypatch):
+    monkeypatch.setenv("SMART_SEARCH_MINIMUM_PROFILE", "standard")
+    monkeypatch.setenv("OPENAI_COMPATIBLE_API_URL", "https://relay.example.com/v1")
+    monkeypatch.setenv("OPENAI_COMPATIBLE_API_KEY", "relay-test-secret")
+    monkeypatch.setenv("EXA_API_KEY", "exa-test-secret")
+    monkeypatch.delenv("TAVILY_API_KEY", raising=False)
+    monkeypatch.delenv("FIRECRAWL_API_KEY", raising=False)
+    monkeypatch.delenv("JINA_API_KEY", raising=False)
+    monkeypatch.setenv("JINA_READER_API_URL", "https://r.jina.ai")
+
+    without_key = service.validate_minimum_profile()
+    assert without_key["ok"] is False
+    assert "web_fetch" in without_key["missing"]
+    assert "jina" not in without_key["capability_status"]["web_fetch"]["configured"]
+
+    monkeypatch.setenv("JINA_API_KEY", "jina-test-secret")
+    with_key = service.validate_minimum_profile()
+    assert with_key["ok"] is True
+    assert with_key["missing"] == []
+    assert with_key["capability_status"]["web_fetch"]["configured"] == ["jina"]
+
+
+def test_zhipu_mcp_key_satisfies_web_search_and_reader_fetch_as_separate_provider(monkeypatch):
+    monkeypatch.setenv("SMART_SEARCH_MINIMUM_PROFILE", "standard")
+    monkeypatch.setenv("OPENAI_COMPATIBLE_API_URL", "https://relay.example.com/v1")
+    monkeypatch.setenv("OPENAI_COMPATIBLE_API_KEY", "relay-test-secret")
+    monkeypatch.setenv("EXA_API_KEY", "exa-test-secret")
+    monkeypatch.setenv("ZHIPU_MCP_API_KEY", "zmcp-test-secret")
+    monkeypatch.delenv("TAVILY_API_KEY", raising=False)
+    monkeypatch.delenv("FIRECRAWL_API_KEY", raising=False)
+
+    result = service.validate_minimum_profile()
+
+    assert result["ok"] is True
+    assert result["missing"] == []
+    assert result["capability_status"]["web_search"]["configured"] == ["zhipu-mcp"]
+    assert result["capability_status"]["web_search"]["fallback_chain"] == ["zhipu", "zhipu-mcp", "tavily", "firecrawl"]
+    assert result["capability_status"]["web_fetch"]["configured"] == ["zhipu-mcp-reader"]
+
+
+@pytest.mark.asyncio
+async def test_zhipu_mcp_web_search_error_records_attempt_and_falls_back_same_capability(monkeypatch):
+    monkeypatch.setenv("SMART_SEARCH_MINIMUM_PROFILE", "standard")
+    monkeypatch.setenv("OPENAI_COMPATIBLE_API_URL", "https://relay.example.com/v1")
+    monkeypatch.setenv("OPENAI_COMPATIBLE_API_KEY", "relay-test-secret")
+    monkeypatch.setenv("EXA_API_KEY", "exa-test-secret")
+    monkeypatch.setenv("FIRECRAWL_API_KEY", "firecrawl-test-secret")
+    monkeypatch.setenv("ZHIPU_MCP_API_KEY", "zmcp-test-secret")
+    monkeypatch.setenv("TAVILY_API_KEY", "tavily-test-secret")
+
+    async def fake_search(self, query, platform="", ctx=None):
+        return "Answer."
+
+    async def failing_zhipu_mcp(query, count=5):
+        return {
+            "ok": False,
+            "provider": "zhipu-mcp",
+            "tool": "webSearchPrime",
+            "error_type": "provider_error",
+            "error": "provider unavailable",
+        }
+
+    async def yes_tavily(query, max_results=6):
+        return [{"url": "https://fallback.example.com", "title": "Fallback", "content": "fallback source"}]
+
+    monkeypatch.setattr(service.OpenAICompatibleSearchProvider, "search", fake_search)
+    monkeypatch.setattr(service, "zhipu_mcp_search", failing_zhipu_mcp)
+    monkeypatch.setattr(service, "call_tavily_search", yes_tavily)
+
+    result = await service.search("latest MCP status", validation="strict")
+
+    web_attempts = [attempt for attempt in result["provider_attempts"] if attempt["capability"] == "web_search"]
+    assert result["ok"] is True
+    assert [attempt["provider"] for attempt in web_attempts[:2]] == ["zhipu-mcp", "tavily"]
+    assert web_attempts[0]["status"] == "error"
+    assert web_attempts[0]["error_type"] == "provider_error"
+    assert web_attempts[1]["status"] == "ok"
+    assert result["extra_sources"][0]["provider"] == "tavily"
+
+
 @pytest.mark.asyncio
 async def test_search_provider_filter_can_select_openai_compatible(monkeypatch):
     monkeypatch.setenv("XAI_API_KEY", "xai-test-secret")
@@ -725,6 +846,8 @@ async def test_search_reports_primary_provider_http_error(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_fetch_prefers_tavily(monkeypatch):
+    monkeypatch.setenv("TAVILY_API_KEY", "tavily-secret")
+
     async def yes_tavily(url):
         return "# Tavily Page"
 
@@ -743,6 +866,9 @@ async def test_fetch_prefers_tavily(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_fetch_fallbacks_to_firecrawl(monkeypatch):
+    monkeypatch.setenv("TAVILY_API_KEY", "tavily-secret")
+    monkeypatch.setenv("FIRECRAWL_API_KEY", "firecrawl-secret")
+
     async def no_tavily(url):
         return None
 
@@ -757,6 +883,61 @@ async def test_fetch_fallbacks_to_firecrawl(monkeypatch):
     assert result["ok"] is True
     assert result["provider"] == "firecrawl"
     assert result["content"] == "# Page"
+
+
+@pytest.mark.asyncio
+async def test_fetch_uses_shared_chain_and_falls_back_after_jina_quality_error(monkeypatch):
+    monkeypatch.setenv("TAVILY_API_KEY", "tavily-secret")
+    monkeypatch.setenv("JINA_API_KEY", "jina-secret")
+    monkeypatch.setenv("FIRECRAWL_API_KEY", "firecrawl-secret")
+
+    async def no_tavily(url):
+        return None
+
+    async def bad_jina(url):
+        return {"ok": False, "provider": "jina", "error_type": "quality_error", "error": "challenge"}
+
+    async def yes_firecrawl(url, ctx=None):
+        return "# Page"
+
+    monkeypatch.setattr(service, "call_tavily_extract", no_tavily)
+    monkeypatch.setattr(service, "jina_fetch", bad_jina)
+    monkeypatch.setattr(service, "call_firecrawl_scrape", yes_firecrawl)
+
+    result = await service.fetch("https://example.com")
+
+    assert result["ok"] is True
+    assert result["provider"] == "firecrawl"
+    assert [a["provider"] for a in result["provider_attempts"]] == ["tavily", "jina", "firecrawl"]
+    assert result["provider_attempts"][1]["error_type"] == "quality_error"
+
+
+@pytest.mark.asyncio
+async def test_search_known_url_uses_same_fetch_chain_as_fetch(monkeypatch):
+    monkeypatch.setenv("OPENAI_COMPATIBLE_API_URL", "https://api.example.com/v1")
+    monkeypatch.setenv("OPENAI_COMPATIBLE_API_KEY", "sk-test-secret")
+    monkeypatch.setenv("EXA_API_KEY", "exa-secret")
+    monkeypatch.setenv("JINA_API_KEY", "jina-secret")
+
+    async def fake_search(self, query, platform="", ctx=None):
+        return "Answer."
+
+    captured = {}
+
+    async def yes_jina(url):
+        captured["url"] = url
+        return {"ok": True, "provider": "jina", "url": url, "content": "# Jina Page"}
+
+    monkeypatch.setattr(service.OpenAICompatibleSearchProvider, "search", fake_search)
+    monkeypatch.setattr(service, "jina_fetch", yes_jina)
+
+    result = await service.search("请抓取 https://example.com/docs?x=1 后总结", validation="balanced")
+
+    assert result["ok"] is True
+    assert captured["url"] == "https://example.com/docs?x=1"
+    attempts = [a for a in result["provider_attempts"] if a["capability"] == "web_fetch"]
+    assert [a["provider"] for a in attempts] == ["jina"]
+    assert result["extra_sources"][0]["provider"] == "jina"
 
 
 @pytest.mark.asyncio
@@ -1363,8 +1544,16 @@ async def test_doctor_tests_main_providers_independently(monkeypatch):
     async def fake_tavily_connection():
         return {"status": "ok", "message": "tavily ok"}
 
+    async def fake_jina_connection():
+        return {"status": "not_configured", "message": "missing"}
+
+    async def fake_zhipu_mcp_connection():
+        return {"status": "not_configured", "message": "missing"}
+
     monkeypatch.setattr(service, "_test_exa_connection", fake_exa_connection)
     monkeypatch.setattr(service, "_test_tavily_connection", fake_tavily_connection)
+    monkeypatch.setattr(service, "_test_jina_connection", fake_jina_connection)
+    monkeypatch.setattr(service, "_test_zhipu_mcp_connection", fake_zhipu_mcp_connection)
 
     result = await service.doctor()
 
@@ -1372,6 +1561,86 @@ async def test_doctor_tests_main_providers_independently(monkeypatch):
     assert result["primary_connection_test"]["status"] == "timeout"
     assert result["main_search_connection_tests"]["xai-responses"]["status"] == "timeout"
     assert result["main_search_connection_tests"]["openai-compatible"]["status"] == "ok"
+
+
+@pytest.mark.asyncio
+async def test_jina_doctor_reports_readerlm_without_key_as_config_error(monkeypatch):
+    monkeypatch.setenv("JINA_RESPOND_WITH", "readerlm-v2")
+    monkeypatch.delenv("JINA_API_KEY", raising=False)
+
+    result = await service._test_jina_connection()
+
+    assert result["status"] == "config_error"
+    assert "JINA_API_KEY" in result["message"]
+
+
+@pytest.mark.asyncio
+async def test_call_jina_reader_decodes_provider_json(monkeypatch):
+    class FakeJinaReaderProvider:
+        def __init__(self, reader_api_url, api_key, respond_with, timeout):
+            pass
+
+        async def fetch(self, url):
+            return json.dumps({"ok": True, "provider": "jina", "url": url, "content": "# Page"})
+
+    monkeypatch.setattr(service, "JinaReaderProvider", FakeJinaReaderProvider)
+
+    result = await service.call_jina_reader("https://example.com")
+
+    assert result == {"ok": True, "provider": "jina", "url": "https://example.com", "content": "# Page"}
+
+
+@pytest.mark.asyncio
+async def test_zhipu_mcp_service_wrappers_decode_provider_json(monkeypatch):
+    calls = []
+
+    class FakeZhipuMCPProvider:
+        def __init__(self, api_url, api_key, timeout, provider_id="zhipu-mcp"):
+            calls.append(("init", provider_id, api_url, api_key, timeout))
+            self.provider_id = provider_id
+
+        async def web_search(self, query, count=5):
+            calls.append(("web_search", query, count))
+            return json.dumps({"ok": True, "provider": self.provider_id, "tool": "webSearchPrime", "query": query})
+
+        async def web_reader(self, url):
+            calls.append(("web_reader", url))
+            return json.dumps({"ok": True, "provider": self.provider_id, "tool": "webReader", "url": url, "content": "# Page"})
+
+        async def search_doc(self, repo, query, max_results=5):
+            calls.append(("search_doc", repo, query, max_results))
+            return json.dumps({"ok": True, "provider": self.provider_id, "tool": "search_doc", "repo": repo})
+
+        async def get_repo_structure(self, repo, ref=""):
+            calls.append(("get_repo_structure", repo, ref))
+            return json.dumps({"ok": True, "provider": self.provider_id, "tool": "get_repo_structure", "repo": repo})
+
+        async def read_file(self, repo, path, ref=""):
+            calls.append(("read_file", repo, path, ref))
+            return json.dumps({"ok": True, "provider": self.provider_id, "tool": "read_file", "path": path})
+
+    monkeypatch.setenv("ZHIPU_MCP_API_KEY", "zmcp-test-secret")
+    monkeypatch.setenv("ZHIPU_MCP_TIMEOUT_SECONDS", "7")
+    monkeypatch.setattr(service, "ZhipuMCPProvider", FakeZhipuMCPProvider)
+
+    search = await service.zhipu_mcp_search("query", count=2)
+    reader = await service.zhipu_mcp_reader("https://example.com")
+    doc = await service.zhipu_mcp_search_doc("owner/repo", "install", max_results=3)
+    tree = await service.zhipu_mcp_repo_structure("owner/repo", ref="main")
+    file_data = await service.zhipu_mcp_read_file("owner/repo", "README.md", ref="main")
+
+    assert search["tool"] == "webSearchPrime"
+    assert reader["content"] == "# Page"
+    assert doc["tool"] == "search_doc"
+    assert tree["tool"] == "get_repo_structure"
+    assert file_data["path"] == "README.md"
+    assert calls[0] == (
+        "init",
+        "zhipu-mcp",
+        "https://open.bigmodel.cn/api/mcp/web_search_prime/mcp",
+        "zmcp-test-secret",
+        7.0,
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -842,7 +842,7 @@ async def test_zhipu_mcp_web_search_error_records_attempt_and_falls_back_same_ca
         return {
             "ok": False,
             "provider": "zhipu-mcp",
-            "tool": "webSearchPrime",
+            "tool": "web_search_prime",
             "error_type": "provider_error",
             "error": "provider unavailable",
         }
@@ -1816,7 +1816,7 @@ async def test_zhipu_mcp_service_wrappers_decode_provider_json(monkeypatch):
 
         async def web_search(self, query, count=5):
             calls.append(("web_search", query, count))
-            return json.dumps({"ok": True, "provider": self.provider_id, "tool": "webSearchPrime", "query": query})
+            return json.dumps({"ok": True, "provider": self.provider_id, "tool": "web_search_prime", "query": query})
 
         async def web_reader(self, url):
             calls.append(("web_reader", url))
@@ -1844,7 +1844,7 @@ async def test_zhipu_mcp_service_wrappers_decode_provider_json(monkeypatch):
     tree = await service.zhipu_mcp_repo_structure("owner/repo", ref="main")
     file_data = await service.zhipu_mcp_read_file("owner/repo", "README.md", ref="main")
 
-    assert search["tool"] == "webSearchPrime"
+    assert search["tool"] == "web_search_prime"
     assert reader["content"] == "# Page"
     assert doc["tool"] == "search_doc"
     assert tree["tool"] == "get_repo_structure"

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,4 +1,5 @@
 import json
+import time
 
 import httpx
 import pytest
@@ -280,6 +281,220 @@ def test_deep_research_quick_budget_keeps_fetch_and_valid_subquestion_links():
     assert all(step["subquestion_id"] in subquestion_ids for step in result["steps"])
     for step in result["steps"]:
         assert step["output_path"] in step["command"]
+
+
+def _configure_research_minimum(monkeypatch):
+    monkeypatch.setenv("OPENAI_COMPATIBLE_API_URL", "https://api.example.com/v1")
+    monkeypatch.setenv("OPENAI_COMPATIBLE_API_KEY", "sk-test-secret")
+    monkeypatch.setenv("CONTEXT7_API_KEY", "ctx-secret")
+    monkeypatch.setenv("EXA_API_KEY", "exa-secret")
+    monkeypatch.setenv("TAVILY_API_KEY", "tavily-secret")
+    monkeypatch.setenv("JINA_API_KEY", "jina-secret")
+
+
+def _research_plan(query: str) -> dict:
+    return service.build_deep_research_plan(query, budget="deep", evidence_dir="C:/tmp/smart-search-evidence/test")
+
+
+def test_research_provider_profiles_are_registered_with_capability_boundaries():
+    profiles = service.provider_profiles()
+
+    assert profiles["jina"]["capability"] == "web_fetch"
+    assert "web_fetch" in profiles["tavily"]["capabilities"]
+    assert "web_search" in profiles["firecrawl"]["capabilities"]
+    assert profiles["jina"]["fallback_group"] == "web_fetch"
+    assert profiles["jina"]["minimum_profile_role"] == "web_fetch_with_key"
+    assert "challenge page rejection" in profiles["jina"]["quality_filters"]
+    assert "known URL extraction" in profiles["jina"]["route_reasons"]
+    assert profiles["anysearch"]["experimental"] is True
+
+
+def test_research_router_prefers_context7_for_docs_and_keeps_anysearch_out(monkeypatch):
+    _configure_research_minimum(monkeypatch)
+
+    routes = service._research_capability_routes("React useEffect API docs", _research_plan("React useEffect API docs"), "auto")
+
+    assert routes["signals"]["docs_api_intent"] is True
+    assert routes["capabilities"]["docs_search"]["providers"][:2] == ["context7", "exa"]
+    assert routes["capabilities"]["vertical_search"]["providers"] == []
+
+
+def test_research_router_uses_zhipu_for_chinese_current_policy(monkeypatch):
+    _configure_research_minimum(monkeypatch)
+    monkeypatch.setenv("ZHIPU_API_KEY", "zhipu-secret")
+
+    routes = service._research_capability_routes("今天国内 AI 政策最新公告", _research_plan("今天国内 AI 政策最新公告"), "auto")
+
+    assert routes["signals"]["current_or_locale_intent"] is True
+    assert routes["capabilities"]["web_search"]["providers"][0] == "zhipu"
+
+
+def test_research_router_favors_jina_for_known_url_pdf_and_firecrawl_for_dynamic(monkeypatch):
+    _configure_research_minimum(monkeypatch)
+    monkeypatch.setenv("FIRECRAWL_API_KEY", "firecrawl-secret")
+
+    assert service._research_fetch_order("summarize https://arxiv.org/pdf/2401.00001.pdf")[0] == "jina"
+    assert service._research_fetch_order("抓取这个 dynamic javascript cloudflare 页面", "https://example.com/app")[0] == "firecrawl"
+
+
+def test_research_router_uses_anysearch_only_for_vertical_intent(monkeypatch):
+    _configure_research_minimum(monkeypatch)
+    monkeypatch.setenv("ANYSEARCH_API_KEY", "any-secret")
+
+    generic = service._research_capability_routes("React useEffect API docs", _research_plan("React useEffect API docs"), "auto")
+    vertical = service._research_capability_routes("CVE-2026 OpenSSL 漏洞影响范围", _research_plan("CVE-2026 OpenSSL 漏洞影响范围"), "auto")
+
+    assert generic["capabilities"]["vertical_search"]["providers"] == []
+    assert vertical["capabilities"]["vertical_search"]["providers"] == ["anysearch"]
+
+
+def test_research_overrides_cannot_move_provider_across_capability(monkeypatch):
+    _configure_research_minimum(monkeypatch)
+    monkeypatch.setenv("SMART_SEARCH_RESEARCH_PREFERRED_PROVIDERS", "jina,zhipu,unknown-provider")
+    monkeypatch.setenv("SMART_SEARCH_RESEARCH_DISABLED_PROVIDERS", "tavily")
+
+    routes = service._research_capability_routes("今天国内 AI 新闻", _research_plan("今天国内 AI 新闻"), "auto")
+
+    assert "unknown-provider" in routes["invalid_provider_overrides"]
+    assert "jina" not in routes["capabilities"]["web_search"]["providers"]
+    assert "tavily" not in routes["capabilities"]["web_fetch"]["providers"]
+    assert routes["capabilities"]["web_fetch"]["providers"][0] == "jina"
+
+
+def test_research_fallback_detection_is_same_capability_only():
+    cross_capability_attempts = [
+        service._attempt("docs_search", "context7", "empty", time.time()),
+        service._attempt("web_fetch", "jina", "ok", time.time(), result_count=1),
+    ]
+    same_capability_attempts = [
+        service._attempt("web_fetch", "jina", "empty", time.time()),
+        service._attempt("web_fetch", "firecrawl", "ok", time.time(), result_count=1),
+    ]
+
+    assert service._fallback_used(cross_capability_attempts) is False
+    assert service._fallback_used(same_capability_attempts) is True
+
+
+@pytest.mark.asyncio
+async def test_research_executes_staged_evidence_only_workflow(monkeypatch, tmp_path):
+    _configure_research_minimum(monkeypatch)
+    monkeypatch.setenv("ZHIPU_API_KEY", "zhipu-secret")
+
+    async def fake_web_search(query, count=5, providers="auto", fallback="auto"):
+        return (
+            [{"url": "https://evidence.example.com/source", "title": "Source", "provider": "zhipu"}],
+            [service._attempt("web_search", "zhipu", "ok", time.time(), result_count=1)],
+        )
+
+    async def fake_fetch(url, fallback="auto", preferred_order=None):
+        return (
+            {"ok": True, "url": url, "provider": "jina", "content": "# Evidence\nFetched body only."},
+            [service._attempt("web_fetch", "jina", "ok", time.time(), result_count=1)],
+        )
+
+    monkeypatch.setattr(service, "_run_web_search_fallback", fake_web_search)
+    monkeypatch.setattr(service, "_run_web_fetch_fallback", fake_fetch)
+
+    result = await service.research("今天国内 AI 新闻", evidence_dir=str(tmp_path), fallback="auto")
+
+    assert result["ok"] is True
+    assert result["query_mode"] == "research"
+    assert result["route_policy_version"] == service.RESEARCH_ROUTE_POLICY_VERSION
+    assert result["evidence_items"][0]["url"] == "https://evidence.example.com/source"
+    assert result["citations"] == [{"url": "https://evidence.example.com/source", "title": "Source", "provider": "jina"}]
+    assert "Fetched body only" in result["final_answer"]
+    assert "zhipu" in [attempt["provider"] for attempt in result["provider_attempts"]]
+    assert (tmp_path / "summary.json").exists()
+
+
+@pytest.mark.asyncio
+async def test_research_reports_degraded_gaps_without_citing_discovery_candidates(monkeypatch, tmp_path):
+    _configure_research_minimum(monkeypatch)
+    monkeypatch.setenv("ZHIPU_API_KEY", "zhipu-secret")
+
+    async def fake_web_search(query, count=5, providers="auto", fallback="auto"):
+        return (
+            [{"url": "https://candidate.example.com", "title": "Candidate", "provider": "zhipu"}],
+            [service._attempt("web_search", "zhipu", "ok", time.time(), result_count=1)],
+        )
+
+    async def fake_fetch(url, fallback="auto", preferred_order=None):
+        return (
+            None,
+            [
+                service._attempt("web_fetch", "jina", "empty", time.time()),
+                service._attempt("web_fetch", "tavily", "empty", time.time()),
+            ],
+        )
+
+    monkeypatch.setattr(service, "_run_web_search_fallback", fake_web_search)
+    monkeypatch.setattr(service, "_run_web_fetch_fallback", fake_fetch)
+
+    result = await service.research("今天国内 AI 新闻", evidence_dir=str(tmp_path), fallback="auto")
+
+    assert result["ok"] is False
+    assert result["degraded"] is True
+    assert result["citations"] == []
+    assert result["evidence_items"] == []
+    assert result["gap_check"]["status"] == "failed"
+    assert result["fallback_used"] is True
+    assert "no fetched/read evidence" in result["gap_check"]["gaps"][-1]["reason"]
+
+
+@pytest.mark.asyncio
+async def test_research_fallback_off_limits_same_capability_fetch(monkeypatch, tmp_path):
+    _configure_research_minimum(monkeypatch)
+
+    async def fake_fetch(url, fallback="auto", preferred_order=None):
+        attempts = [service._attempt("web_fetch", preferred_order[0], "empty", time.time())]
+        return None, attempts
+
+    async def should_not_discover(*args, **kwargs):
+        raise AssertionError("known URL with fallback off should not need discovery after fetch failure")
+
+    monkeypatch.setattr(service, "_run_web_fetch_fallback", fake_fetch)
+    monkeypatch.setattr(service, "_run_web_search_fallback", should_not_discover)
+
+    result = await service.research("https://example.com/source", evidence_dir=str(tmp_path), fallback="off")
+
+    fetch_attempts = [attempt for attempt in result["provider_attempts"] if attempt["capability"] == "web_fetch"]
+    assert [attempt["provider"] for attempt in fetch_attempts] == ["jina"]
+    assert result["fallback_used"] is False
+    assert result["gap_check"]["status"] == "failed"
+
+
+@pytest.mark.asyncio
+async def test_research_fallback_off_does_not_run_supplemental_exa(monkeypatch, tmp_path):
+    _configure_research_minimum(monkeypatch)
+    monkeypatch.setenv("ZHIPU_API_KEY", "zhipu-secret")
+
+    async def fake_context7_library(*args, **kwargs):
+        return {"ok": False, "error_type": "", "error": "", "results": []}
+
+    async def fail_exa(*args, **kwargs):
+        raise AssertionError("research --fallback off must not run supplemental Exa outside the selected route")
+
+    async def fake_web_search(query, count=5, providers="auto", fallback="auto"):
+        return (
+            [{"url": "https://official.example.com/source", "title": "Official", "provider": "zhipu"}],
+            [service._attempt("web_search", "zhipu", "ok", time.time(), result_count=1)],
+        )
+
+    async def fake_fetch(url, fallback="auto", preferred_order=None):
+        return (
+            {"ok": True, "url": url, "provider": preferred_order[0], "content": "# Evidence\nOfficial body."},
+            [service._attempt("web_fetch", preferred_order[0], "ok", time.time(), result_count=1)],
+        )
+
+    monkeypatch.setattr(service, "context7_library", fake_context7_library)
+    monkeypatch.setattr(service, "exa_search", fail_exa)
+    monkeypatch.setattr(service, "_run_web_search_fallback", fake_web_search)
+    monkeypatch.setattr(service, "_run_web_fetch_fallback", fake_fetch)
+
+    result = await service.research("React official API docs", evidence_dir=str(tmp_path), fallback="off")
+
+    assert result["ok"] is True
+    assert all(attempt["provider"] != "exa" for attempt in result["provider_attempts"])
 
 
 def test_legacy_main_search_config_keys_are_rejected(monkeypatch, tmp_path):

--- a/tests/test_zhipu_mcp_provider.py
+++ b/tests/test_zhipu_mcp_provider.py
@@ -1,0 +1,154 @@
+import json
+
+import httpx
+import pytest
+
+from smart_search.providers.zhipu_mcp import ZhipuMCPProvider
+
+
+class FakeZhipuMCPClient:
+    calls = []
+    response: httpx.Response | None = None
+    exception: Exception | None = None
+
+    def __init__(self, timeout, follow_redirects=True):
+        self.timeout = timeout
+        self.follow_redirects = follow_redirects
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return None
+
+    async def post(self, url, headers, json):
+        self.__class__.calls.append({"url": url, "headers": headers, "json": json, "timeout": self.timeout})
+        if self.__class__.exception:
+            raise self.__class__.exception
+        return self.__class__.response
+
+
+@pytest.fixture(autouse=True)
+def reset_fake_client():
+    FakeZhipuMCPClient.calls = []
+    FakeZhipuMCPClient.response = None
+    FakeZhipuMCPClient.exception = None
+
+
+@pytest.mark.asyncio
+async def test_zhipu_mcp_web_search_calls_tool_and_parses_results(monkeypatch):
+    FakeZhipuMCPClient.response = httpx.Response(
+        200,
+        json={
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "### 1. Result\n- **URL**: https://example.com\nSnippet",
+                    }
+                ]
+            },
+        },
+        request=httpx.Request("POST", "https://open.bigmodel.cn/api/mcp/web_search_prime/mcp"),
+    )
+    monkeypatch.setattr("smart_search.providers.zhipu_mcp.httpx.AsyncClient", FakeZhipuMCPClient)
+
+    provider = ZhipuMCPProvider("https://open.bigmodel.cn/api/mcp/web_search_prime/mcp", "zmcp-secret")
+    data = json.loads(await provider.web_search("query", count=2))
+
+    assert data["ok"] is True
+    assert data["provider"] == "zhipu-mcp"
+    assert data["tool"] == "webSearchPrime"
+    assert data["results"][0]["url"] == "https://example.com"
+    call = FakeZhipuMCPClient.calls[0]
+    assert call["headers"]["Authorization"] == "Bearer zmcp-secret"
+    assert call["json"]["method"] == "tools/call"
+    assert call["json"]["params"]["name"] == "webSearchPrime"
+    assert call["json"]["params"]["arguments"] == {"query": "query", "count": 2}
+
+
+@pytest.mark.asyncio
+async def test_zhipu_mcp_reader_returns_content(monkeypatch):
+    FakeZhipuMCPClient.response = httpx.Response(
+        200,
+        json={"jsonrpc": "2.0", "id": 1, "result": {"content": [{"type": "text", "text": "# Page"}]}},
+        request=httpx.Request("POST", "https://open.bigmodel.cn/api/mcp/web_reader/mcp"),
+    )
+    monkeypatch.setattr("smart_search.providers.zhipu_mcp.httpx.AsyncClient", FakeZhipuMCPClient)
+
+    provider = ZhipuMCPProvider("https://open.bigmodel.cn/api/mcp/web_reader/mcp", "zmcp-secret", provider_id="zhipu-mcp-reader")
+    data = json.loads(await provider.web_reader("https://example.com"))
+
+    assert data["ok"] is True
+    assert data["provider"] == "zhipu-mcp-reader"
+    assert data["tool"] == "webReader"
+    assert data["content"] == "# Page"
+    assert FakeZhipuMCPClient.calls[0]["json"]["params"]["arguments"] == {"url": "https://example.com"}
+
+
+@pytest.mark.asyncio
+async def test_zhipu_mcp_zread_tools_send_expected_arguments(monkeypatch):
+    FakeZhipuMCPClient.response = httpx.Response(
+        200,
+        json={"jsonrpc": "2.0", "id": 1, "result": {"content": [{"type": "text", "text": "ok"}]}},
+        request=httpx.Request("POST", "https://open.bigmodel.cn/api/mcp/zread/mcp"),
+    )
+    monkeypatch.setattr("smart_search.providers.zhipu_mcp.httpx.AsyncClient", FakeZhipuMCPClient)
+
+    provider = ZhipuMCPProvider("https://open.bigmodel.cn/api/mcp/zread/mcp", "zmcp-secret", provider_id="zhipu-mcp-zread")
+    await provider.search_doc("owner/repo", "install", max_results=3)
+    await provider.get_repo_structure("owner/repo", ref="main")
+    await provider.read_file("owner/repo", "README.md", ref="main")
+
+    assert [call["json"]["params"]["name"] for call in FakeZhipuMCPClient.calls] == [
+        "search_doc",
+        "get_repo_structure",
+        "read_file",
+    ]
+    assert FakeZhipuMCPClient.calls[0]["json"]["params"]["arguments"] == {
+        "repo": "owner/repo",
+        "query": "install",
+        "max_results": 3,
+    }
+    assert FakeZhipuMCPClient.calls[2]["json"]["params"]["arguments"] == {
+        "repo": "owner/repo",
+        "path": "README.md",
+        "ref": "main",
+    }
+
+
+@pytest.mark.asyncio
+async def test_zhipu_mcp_http_401_is_auth_error(monkeypatch):
+    FakeZhipuMCPClient.response = httpx.Response(
+        401,
+        text="invalid token",
+        request=httpx.Request("POST", "https://open.bigmodel.cn/api/mcp/web_search_prime/mcp"),
+    )
+    monkeypatch.setattr("smart_search.providers.zhipu_mcp.httpx.AsyncClient", FakeZhipuMCPClient)
+
+    provider = ZhipuMCPProvider("https://open.bigmodel.cn/api/mcp/web_search_prime/mcp", "zmcp-secret")
+    data = json.loads(await provider.web_search("query"))
+
+    assert data["ok"] is False
+    assert data["error_type"] == "auth_error"
+    assert "HTTP 401" in data["error"]
+    assert "zmcp-secret" not in data["error"]
+
+
+@pytest.mark.asyncio
+async def test_zhipu_mcp_sse_response_is_parsed(monkeypatch):
+    FakeZhipuMCPClient.response = httpx.Response(
+        200,
+        text='event: message\ndata: {"jsonrpc":"2.0","id":1,"result":{"content":[{"type":"text","text":"### Result\\nhttps://example.com"}]}}\n\n',
+        headers={"content-type": "text/event-stream"},
+        request=httpx.Request("POST", "https://open.bigmodel.cn/api/mcp/web_search_prime/mcp"),
+    )
+    monkeypatch.setattr("smart_search.providers.zhipu_mcp.httpx.AsyncClient", FakeZhipuMCPClient)
+
+    provider = ZhipuMCPProvider("https://open.bigmodel.cn/api/mcp/web_search_prime/mcp", "zmcp-secret")
+    data = json.loads(await provider.web_search("query"))
+
+    assert data["ok"] is True
+    assert data["results"][0]["url"] == "https://example.com"

--- a/tests/test_zhipu_mcp_provider.py
+++ b/tests/test_zhipu_mcp_provider.py
@@ -60,13 +60,13 @@ async def test_zhipu_mcp_web_search_calls_tool_and_parses_results(monkeypatch):
 
     assert data["ok"] is True
     assert data["provider"] == "zhipu-mcp"
-    assert data["tool"] == "webSearchPrime"
+    assert data["tool"] == "web_search_prime"
     assert data["results"][0]["url"] == "https://example.com"
     call = FakeZhipuMCPClient.calls[0]
     assert call["headers"]["Authorization"] == "Bearer zmcp-secret"
     assert call["json"]["method"] == "tools/call"
-    assert call["json"]["params"]["name"] == "webSearchPrime"
-    assert call["json"]["params"]["arguments"] == {"query": "query", "count": 2}
+    assert call["json"]["params"]["name"] == "web_search_prime"
+    assert call["json"]["params"]["arguments"] == {"search_query": "query"}
 
 
 @pytest.mark.asyncio
@@ -89,6 +89,48 @@ async def test_zhipu_mcp_reader_returns_content(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_zhipu_mcp_reader_json_error_text_is_provider_error(monkeypatch):
+    FakeZhipuMCPClient.response = httpx.Response(
+        200,
+        json={
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {"content": [{"type": "text", "text": '"{\\"error\\":\\"fetch failed\\"}"'}]},
+        },
+        request=httpx.Request("POST", "https://open.bigmodel.cn/api/mcp/web_reader/mcp"),
+    )
+    monkeypatch.setattr("smart_search.providers.zhipu_mcp.httpx.AsyncClient", FakeZhipuMCPClient)
+
+    provider = ZhipuMCPProvider("https://open.bigmodel.cn/api/mcp/web_reader/mcp", "zmcp-secret", provider_id="zhipu-mcp-reader")
+    data = json.loads(await provider.web_reader("https://example.com"))
+
+    assert data["ok"] is False
+    assert data["error_type"] == "provider_error"
+    assert data["error"] == "fetch failed"
+
+
+@pytest.mark.asyncio
+async def test_zhipu_mcp_content_mcp_401_is_auth_error(monkeypatch):
+    FakeZhipuMCPClient.response = httpx.Response(
+        200,
+        json={
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {"content": [{"type": "text", "text": "MCP error -401: Api key not found"}]},
+        },
+        request=httpx.Request("POST", "https://open.bigmodel.cn/api/mcp/web_search_prime/mcp"),
+    )
+    monkeypatch.setattr("smart_search.providers.zhipu_mcp.httpx.AsyncClient", FakeZhipuMCPClient)
+
+    provider = ZhipuMCPProvider("https://open.bigmodel.cn/api/mcp/web_search_prime/mcp", "zmcp-secret")
+    data = json.loads(await provider.web_search("query"))
+
+    assert data["ok"] is False
+    assert data["error_type"] == "auth_error"
+    assert "Api key not found" in data["error"]
+
+
+@pytest.mark.asyncio
 async def test_zhipu_mcp_zread_tools_send_expected_arguments(monkeypatch):
     FakeZhipuMCPClient.response = httpx.Response(
         200,
@@ -108,14 +150,12 @@ async def test_zhipu_mcp_zread_tools_send_expected_arguments(monkeypatch):
         "read_file",
     ]
     assert FakeZhipuMCPClient.calls[0]["json"]["params"]["arguments"] == {
-        "repo": "owner/repo",
+        "repo_name": "owner/repo",
         "query": "install",
-        "max_results": 3,
     }
     assert FakeZhipuMCPClient.calls[2]["json"]["params"]["arguments"] == {
-        "repo": "owner/repo",
-        "path": "README.md",
-        "ref": "main",
+        "repo_name": "owner/repo",
+        "file_path": "README.md",
     }
 
 


### PR DESCRIPTION
## Summary
- add live `smart-search research` with provider-advantage routing, same-capability fallback, and evidence-only synthesis
- add controlled Jina `web_fetch` support plus an isolated Jina capability probe script
- add separate Zhipu Coding Plan MCP routes and align live tool schemas/error normalization
- document provider boundaries, minimum-profile behavior, fallback semantics, and beta release notes

## Tests
- `.\.venv\Scripts\python.exe -m compileall -q src tests`
- `.\.venv\Scripts\python.exe -m pytest -q`
- `.\.venv\Scripts\python.exe -m smart_search.cli regression`
- `.\.venv\Scripts\python.exe -m smart_search.cli smoke --mock --format json`
- `npm test`
- `npm pack --dry-run`
- `git diff --check`