### PR TITLE
fix: use platform temp dir for deep evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,7 +454,7 @@ smart-search doctor --format content
 
 `content` is intentionally brief. Use `doctor --format markdown` for general human troubleshooting, `diagnose openai-compatible --format markdown` for OpenAI-compatible search hangs/timeouts, and JSON formats for complete machine-readable contracts.
 
-Save multi-source evidence under a stable folder:
+Save multi-source evidence under an explicit stable folder. The default uses the platform temp directory; the commands below use a Windows explicit path example:
 
 ```powershell
 smart-search exa-search "Reuters Iran Hormuz latest" --format json --output C:\tmp\smart-search-evidence\iran-hormuz\01-exa.json

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -503,7 +503,7 @@ smart-search doctor --format content
 
 `content` 刻意保持很短，只适合快速看结论。完整排障给人看用 `doctor --format markdown`，给脚本和 AI 解析用 `doctor --format json`。
 
-多来源研究建议保存证据文件：
+多来源研究建议显式指定稳定目录保存证据文件。默认使用平台临时目录，以 Windows 显式路径为例：
 
 ```powershell
 smart-search exa-search "Reuters Iran Hormuz latest" --format json --output C:\tmp\smart-search-evidence\iran-hormuz\01-exa.json

--- a/skills/smart-search-cli/references/cli-contract.md
+++ b/skills/smart-search-cli/references/cli-contract.md
@@ -239,7 +239,7 @@ Before execution, the skill should call `smart-search deep "question" --format j
 - `final_answer_policy`: how to cite fetched evidence and list unverified candidates.
 - `usage_boundary`: user-facing distinction between fast live `search`, offline `deep` planning, and later step execution.
 
-Each `steps[]` item must include `id`, `subquestion_id`, `tool`, `purpose`, `command`, and `output_path`. Allowed `tool` values are `search`, `exa-search`, `exa-similar`, `zhipu-search`, `context7-library`, `context7-docs`, `fetch`, and `map`; these map to existing CLI commands only. `doctor` is a `preflight` action, not a `steps[]` item. Use `C:\tmp\smart-search-evidence\<timestamp>-<slug>\` or an equivalent absolute evidence directory for `output_path` values.
+Each `steps[]` item must include `id`, `subquestion_id`, `tool`, `purpose`, `command`, and `output_path`. Allowed `tool` values are `search`, `exa-search`, `exa-similar`, `zhipu-search`, `context7-library`, `context7-docs`, `fetch`, and `map`; these map to existing CLI commands only. `doctor` is a `preflight` action, not a `steps[]` item. Default `output_path` values live under the platform temp directory as `<platform-temp-dir>/smart-search-evidence/<timestamp>-<slug>/...`; explicit `--evidence-dir PATH` values must be preserved as supplied.
 
 Capability boundaries:
 
@@ -267,6 +267,7 @@ Default Deep Research orchestration:
 When the user wants the CLI to execute the live workflow directly, call:
 
 ```powershell
+# Windows explicit-output example
 smart-search research "question" --budget deep --fallback auto --format json --output C:\tmp\smart-search-evidence\research.json
 ```
 

--- a/src/smart_search/assets/skills/smart-search-cli/references/cli-contract.md
+++ b/src/smart_search/assets/skills/smart-search-cli/references/cli-contract.md
@@ -239,7 +239,7 @@ Before execution, the skill should call `smart-search deep "question" --format j
 - `final_answer_policy`: how to cite fetched evidence and list unverified candidates.
 - `usage_boundary`: user-facing distinction between fast live `search`, offline `deep` planning, and later step execution.
 
-Each `steps[]` item must include `id`, `subquestion_id`, `tool`, `purpose`, `command`, and `output_path`. Allowed `tool` values are `search`, `exa-search`, `exa-similar`, `zhipu-search`, `context7-library`, `context7-docs`, `fetch`, and `map`; these map to existing CLI commands only. `doctor` is a `preflight` action, not a `steps[]` item. Use `C:\tmp\smart-search-evidence\<timestamp>-<slug>\` or an equivalent absolute evidence directory for `output_path` values.
+Each `steps[]` item must include `id`, `subquestion_id`, `tool`, `purpose`, `command`, and `output_path`. Allowed `tool` values are `search`, `exa-search`, `exa-similar`, `zhipu-search`, `context7-library`, `context7-docs`, `fetch`, and `map`; these map to existing CLI commands only. `doctor` is a `preflight` action, not a `steps[]` item. Default `output_path` values live under the platform temp directory as `<platform-temp-dir>/smart-search-evidence/<timestamp>-<slug>/...`; explicit `--evidence-dir PATH` values must be preserved as supplied.
 
 Capability boundaries:
 
@@ -267,6 +267,7 @@ Default Deep Research orchestration:
 When the user wants the CLI to execute the live workflow directly, call:
 
 ```powershell
+# Windows explicit-output example
 smart-search research "question" --budget deep --fallback auto --format json --output C:\tmp\smart-search-evidence\research.json
 ```
 

--- a/src/smart_search/service.py
+++ b/src/smart_search/service.py
@@ -2,6 +2,7 @@ import asyncio
 import hashlib
 import json
 import re
+import tempfile
 import time
 from pathlib import Path
 from typing import Any
@@ -716,7 +717,7 @@ def _slugify_query(query: str) -> str:
 
 def _default_evidence_dir(query: str) -> str:
     timestamp = time.strftime("%Y%m%d-%H%M")
-    return str(Path("C:/tmp/smart-search-evidence") / f"{timestamp}-{_slugify_query(query)}")
+    return str(Path(tempfile.gettempdir()) / "smart-search-evidence" / f"{timestamp}-{_slugify_query(query)}")
 
 
 def _quote_arg(value: str) -> str:

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -377,6 +377,22 @@ def test_deep_research_plan_current_market_is_offline_and_fetch_before_claim(mon
     assert all(step["subquestion_id"] for step in result["steps"])
 
 
+def test_deep_research_default_evidence_dir_uses_platform_temp_dir(monkeypatch, tmp_path):
+    monkeypatch.setattr(service.tempfile, "gettempdir", lambda: str(tmp_path))
+    result = service.build_deep_research_plan("Deep research default evidence directory")
+
+    expected_root = tmp_path / "smart-search-evidence"
+    evidence_dir = result["evidence_dir"]
+    evidence_path = service.Path(evidence_dir)
+
+    assert evidence_path.is_absolute()
+    assert evidence_path.parent == expected_root
+    assert evidence_path.name.endswith("-deep-research-default-evidence-directory")
+    for step in result["steps"]:
+        assert service.Path(step["output_path"]).parent == evidence_path
+        assert step["output_path"] in step["command"]
+
+
 def test_deep_research_plan_complex_docs_query_has_decomposition():
     result = service.build_deep_research_plan(
         "OpenAI Responses API web_search 和 Chat Completions 联网搜索怎么选",


### PR DESCRIPTION
Use the platform temp directory for the default Deep Research evidence root instead of the previous Windows-specific C:/tmp/smart-search-evidence path. Explicit --evidence-dir values are still preserved as supplied, and generated step output_path values continue to match the --output paths embedded in the planned commands.

Add service coverage for the default evidence directory, absolute path shape, per-step output placement, and output_path/command consistency. Update README and shared CLI contract docs to describe the platform-temp default while keeping Windows paths as explicit examples.

SKILL.md content and structural changes are intentionally out of scope for this PR; they belong to another PR.