### PR TITLE
fix(anysearch): align MCP tools and support sub_domain_params

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,12 +344,12 @@ Experimental AnySearch configuration is optional and does not satisfy or change 
 ```powershell
 smart-search setup --non-interactive --anysearch-api-url "https://api.anysearch.com/mcp" --anysearch-key "your-anysearch-key"
 smart-search anysearch-domains security --format json
-smart-search anysearch-search "CVE-2024-3094" --domain security.cve --max-results 3 --format json
+smart-search anysearch-search "CVE-2024-3094" --domain security --sub-domain security.vuln --param type=cve --param value=CVE-2024-3094 --max-results 3 --format json
 smart-search anysearch-extract "https://example.com/source" --format json
 smart-search anysearch-batch "AAPL" "RAG papers" --max-results 2 --format json
 ```
 
-For vertical domains, the dotted shorthand `security.cve` is accepted by the CLI and sent to AnySearch as `domain=security` plus `sub_domain=cve`. You can also pass the split form explicitly with `--domain security --sub-domain cve`.
+For vertical domains, the dotted shorthand `security.cve` is accepted by the CLI and sent to AnySearch as `domain=security` plus `sub_domain=cve`. You can also pass the split form explicitly with `--domain security --sub-domain cve`. Structured vertical params use `--sub-domain-params '{"type":"cve","value":"CVE-2024-3094"}'` or repeatable `--param key=value`. `anysearch-domains` maps to the live `get_sub_domains` tool.
 
 Local config path:
 
@@ -416,7 +416,7 @@ smart-search zhipu-search "today China AI news" --search-engine search_pro_sogou
 smart-search zhipu-mcp-search "today China AI news" --count 5 --format json
 smart-search zhipu-mcp-reader "https://example.com/source" --format json
 smart-search zhipu-mcp-search-doc "owner/repo" "install" --format json
-smart-search anysearch-search "CVE-2024-3094" --domain security.cve --max-results 3 --format json
+smart-search anysearch-search "CVE-2024-3094" --domain security --sub-domain security.vuln --param type=cve --param value=CVE-2024-3094 --max-results 3 --format json
 smart-search anysearch-extract "https://example.com/source" --format json
 smart-search exa-similar "https://example.com/source" --num-results 5 --format json
 smart-search fetch "https://example.com/source" --format markdown --output page.md

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -353,12 +353,12 @@ AnySearch 是可选实验配置，不满足也不改变 `standard` 最低配置�
 ```powershell
 smart-search setup --non-interactive --anysearch-api-url "https://api.anysearch.com/mcp" --anysearch-key "your-anysearch-key"
 smart-search anysearch-domains security --format json
-smart-search anysearch-search "CVE-2024-3094" --domain security.cve --max-results 3 --format json
+smart-search anysearch-search "CVE-2024-3094" --domain security --sub-domain security.vuln --param type=cve --param value=CVE-2024-3094 --max-results 3 --format json
 smart-search anysearch-extract "https://example.com/source" --format json
 smart-search anysearch-batch "AAPL" "RAG papers" --max-results 2 --format json
 ```
 
-垂直域支持点号简写：`security.cve` 会由 CLI 发成 `domain=security` 加 `sub_domain=cve`。也可以显式写成 `--domain security --sub-domain cve`。
+垂直域支持点号简写：`security.cve` 会由 CLI 发成 `domain=security` 加 `sub_domain=cve`。也可以显式写成 `--domain security --sub-domain cve`。结构化垂搜参数用 `--sub-domain-params '{"type":"cve","value":"CVE-2024-3094"}'` 或重复 `--param key=value`。`anysearch-domains` 对应服务端 `get_sub_domains`。
 
 本机配置文件位置：
 
@@ -466,7 +466,7 @@ smart-search zhipu-search "今天国内 AI 新闻" --search-engine search_pro_so
 smart-search zhipu-mcp-search "今天国内 AI 新闻" --count 5 --format json
 smart-search zhipu-mcp-reader "https://example.com/source" --format json
 smart-search zhipu-mcp-search-doc "owner/repo" "install" --format json
-smart-search anysearch-search "CVE-2024-3094" --domain security.cve --max-results 3 --format json
+smart-search anysearch-search "CVE-2024-3094" --domain security --sub-domain security.vuln --param type=cve --param value=CVE-2024-3094 --max-results 3 --format json
 smart-search anysearch-extract "https://example.com/source" --format json
 smart-search exa-similar "https://example.com/source" --num-results 5 --format json
 smart-search fetch "https://example.com/source" --format markdown --output page.md

--- a/skills/smart-search-cli/references/cli-core.md
+++ b/skills/smart-search-cli/references/cli-core.md
@@ -32,7 +32,7 @@
 - `smart-search zhipu-mcp-repo-structure REPO [--ref REF] [--format json|markdown|content] [--output PATH]`
 - `smart-search zhipu-mcp-read-file REPO PATH [--ref REF] [--format json|markdown|content] [--output PATH]`
 - `smart-search anysearch-domains [DOMAIN] [--format json|markdown|content] [--output PATH]`
-- `smart-search anysearch-search QUERY [--domain DOMAIN] [--sub-domain SUB_DOMAIN] [--max-results N] [--format json|markdown|content] [--output PATH]`
+- `smart-search anysearch-search QUERY [--domain DOMAIN] [--sub-domain SUB_DOMAIN] [--sub-domain-params JSON] [--param KEY=VALUE] [--max-results N] [--format json|markdown|content] [--output PATH]`
 - `smart-search anysearch-extract URL [--max-length N] [--format json|markdown|content] [--output PATH]`
 - `smart-search anysearch-batch QUERY... [--max-results N] [--format json|markdown|content] [--output PATH]`
 - `smart-search context7-library NAME [QUERY] [--format json|markdown|content] [--output PATH]`

--- a/skills/smart-search-cli/references/command-patterns.md
+++ b/skills/smart-search-cli/references/command-patterns.md
@@ -35,7 +35,8 @@ smart-search context7-library "react" "hooks" --format json
 smart-search context7-docs "/facebook/react" "useEffect cleanup" --format json
 smart-search zhipu-search "today China AI news" --count 5 --format json
 smart-search anysearch-domains security --format json
-smart-search anysearch-search "CVE-2024-3094" --domain security.cve --max-results 3 --format json
+smart-search anysearch-search "CVE-2024-3094" --domain security --sub-domain security.vuln --param type=cve --param value=CVE-2024-3094 --max-results 3 --format json
+smart-search anysearch-search "CVE-2024-3094" --domain security.cve --sub-domain-params '{"type":"cve","value":"CVE-2024-3094"}' --format json
 smart-search anysearch-extract "https://example.com/source" --format json
 smart-search anysearch-batch "AAPL" "RAG papers" --max-results 2 --format json
 smart-search fetch "https://example.com" --format markdown --output page.md

--- a/skills/smart-search-cli/references/provider-routing.md
+++ b/skills/smart-search-cli/references/provider-routing.md
@@ -102,10 +102,14 @@ AnySearch:
 - AnySearch uses JSON-RPC 2.0 `tools/call` at `ANYSEARCH_API_URL`, default `https://api.anysearch.com/mcp`.
 - `ANYSEARCH_API_KEY` is optional. If configured, requests include `Authorization: Bearer ...`; if missing, anonymous requests are allowed.
 - `ANYSEARCH_TIMEOUT_SECONDS` defaults to `30`.
+- Live MCP tools are `search`, `batch_search`, `extract`, and `get_sub_domains`. `anysearch-domains` maps to `get_sub_domains` (not the removed `list_domains` tool).
+- `anysearch-domains` without a domain returns a local top-level domain catalog. With a domain, it calls `get_sub_domains` using `domains=[parent]`.
 - HTTP 200 responses with `result.isError=true` must return `ok=false`, `error_type=provider_error`, and no successful source results.
 - Markdown URL/title/snippet candidates should be parsed into `results`, while raw text remains in `content` and `raw_content`.
 - Structured results without URLs must be preserved as raw/structured evidence, not dropped.
 - Dotted vertical domain shorthand such as `security.cve` must be normalized to `domain=security` plus `sub_domain=cve` before calling AnySearch.
+- Structured vertical queries may pass `sub_domain_params` via `--sub-domain-params JSON` and/or repeatable `--param KEY=VALUE`.
+- `anysearch-extract --max-length` truncates locally; the live `extract` tool only accepts `url`.
 - `anysearch-batch` accepts at most 5 CLI query strings and returns `error_type=parameter_error` without sending a request when the limit is exceeded.
 
 OpenAI-compatible streaming:

--- a/src/smart_search/assets/skills/smart-search-cli/references/cli-core.md
+++ b/src/smart_search/assets/skills/smart-search-cli/references/cli-core.md
@@ -32,7 +32,7 @@
 - `smart-search zhipu-mcp-repo-structure REPO [--ref REF] [--format json|markdown|content] [--output PATH]`
 - `smart-search zhipu-mcp-read-file REPO PATH [--ref REF] [--format json|markdown|content] [--output PATH]`
 - `smart-search anysearch-domains [DOMAIN] [--format json|markdown|content] [--output PATH]`
-- `smart-search anysearch-search QUERY [--domain DOMAIN] [--sub-domain SUB_DOMAIN] [--max-results N] [--format json|markdown|content] [--output PATH]`
+- `smart-search anysearch-search QUERY [--domain DOMAIN] [--sub-domain SUB_DOMAIN] [--sub-domain-params JSON] [--param KEY=VALUE] [--max-results N] [--format json|markdown|content] [--output PATH]`
 - `smart-search anysearch-extract URL [--max-length N] [--format json|markdown|content] [--output PATH]`
 - `smart-search anysearch-batch QUERY... [--max-results N] [--format json|markdown|content] [--output PATH]`
 - `smart-search context7-library NAME [QUERY] [--format json|markdown|content] [--output PATH]`

--- a/src/smart_search/assets/skills/smart-search-cli/references/command-patterns.md
+++ b/src/smart_search/assets/skills/smart-search-cli/references/command-patterns.md
@@ -35,7 +35,8 @@ smart-search context7-library "react" "hooks" --format json
 smart-search context7-docs "/facebook/react" "useEffect cleanup" --format json
 smart-search zhipu-search "today China AI news" --count 5 --format json
 smart-search anysearch-domains security --format json
-smart-search anysearch-search "CVE-2024-3094" --domain security.cve --max-results 3 --format json
+smart-search anysearch-search "CVE-2024-3094" --domain security --sub-domain security.vuln --param type=cve --param value=CVE-2024-3094 --max-results 3 --format json
+smart-search anysearch-search "CVE-2024-3094" --domain security.cve --sub-domain-params '{"type":"cve","value":"CVE-2024-3094"}' --format json
 smart-search anysearch-extract "https://example.com/source" --format json
 smart-search anysearch-batch "AAPL" "RAG papers" --max-results 2 --format json
 smart-search fetch "https://example.com" --format markdown --output page.md

--- a/src/smart_search/assets/skills/smart-search-cli/references/provider-routing.md
+++ b/src/smart_search/assets/skills/smart-search-cli/references/provider-routing.md
@@ -102,10 +102,14 @@ AnySearch:
 - AnySearch uses JSON-RPC 2.0 `tools/call` at `ANYSEARCH_API_URL`, default `https://api.anysearch.com/mcp`.
 - `ANYSEARCH_API_KEY` is optional. If configured, requests include `Authorization: Bearer ...`; if missing, anonymous requests are allowed.
 - `ANYSEARCH_TIMEOUT_SECONDS` defaults to `30`.
+- Live MCP tools are `search`, `batch_search`, `extract`, and `get_sub_domains`. `anysearch-domains` maps to `get_sub_domains` (not the removed `list_domains` tool).
+- `anysearch-domains` without a domain returns a local top-level domain catalog. With a domain, it calls `get_sub_domains` using `domains=[parent]`.
 - HTTP 200 responses with `result.isError=true` must return `ok=false`, `error_type=provider_error`, and no successful source results.
 - Markdown URL/title/snippet candidates should be parsed into `results`, while raw text remains in `content` and `raw_content`.
 - Structured results without URLs must be preserved as raw/structured evidence, not dropped.
 - Dotted vertical domain shorthand such as `security.cve` must be normalized to `domain=security` plus `sub_domain=cve` before calling AnySearch.
+- Structured vertical queries may pass `sub_domain_params` via `--sub-domain-params JSON` and/or repeatable `--param KEY=VALUE`.
+- `anysearch-extract --max-length` truncates locally; the live `extract` tool only accepts `url`.
 - `anysearch-batch` accepts at most 5 CLI query strings and returns `error_type=parameter_error` without sending a request when the limit is exceeded.
 
 OpenAI-compatible streaming:

--- a/src/smart_search/cli.py
+++ b/src/smart_search/cli.py
@@ -16,6 +16,7 @@ from .embedding_presets import (
     QWEN3_EMBEDDING_8B_PRESET,
     embedding_preset_for_model,
 )
+from .providers.anysearch import parse_sub_domain_params
 from .skill_installer import (
     DEFAULT_SKILL_TARGET_IDS,
     SKILL_TARGETS,
@@ -2455,11 +2456,26 @@ async def _run_async(args: argparse.Namespace) -> int:
         data = await service.anysearch_domains(args.domain)
         return _print_result("anysearch-domains", data, args.format, args.output)
     if args.command == "anysearch-search":
+        try:
+            sub_domain_params = parse_sub_domain_params(
+                getattr(args, "sub_domain_params", "") or "",
+                getattr(args, "param", None) or [],
+            )
+        except ValueError as exc:
+            data = {
+                "ok": False,
+                "provider": "anysearch",
+                "tool": "search",
+                "error_type": "parameter_error",
+                "error": str(exc),
+            }
+            return _print_result("anysearch-search", data, args.format, args.output)
         data = await service.anysearch_search(
             args.query,
             domain=args.domain,
             sub_domain=args.sub_domain,
             max_results=args.max_results,
+            sub_domain_params=sub_domain_params or None,
         )
         return _print_result("anysearch-search", data, args.format, args.output)
     if args.command == "anysearch-extract":
@@ -2886,6 +2902,17 @@ def build_parser() -> argparse.ArgumentParser:
     anysearch_search_parser.add_argument("query")
     anysearch_search_parser.add_argument("--domain", default="")
     anysearch_search_parser.add_argument("--sub-domain", default="")
+    anysearch_search_parser.add_argument(
+        "--sub-domain-params",
+        default="",
+        help='JSON object for structured vertical params, e.g. \'{"type":"cve","value":"CVE-2024-3094"}\'.',
+    )
+    anysearch_search_parser.add_argument(
+        "--param",
+        action="append",
+        default=[],
+        help="Repeatable key=value entries merged into sub_domain_params.",
+    )
     anysearch_search_parser.add_argument("--max-results", type=int, default=5)
     _add_format_args(anysearch_search_parser)
 

--- a/src/smart_search/providers/anysearch.py
+++ b/src/smart_search/providers/anysearch.py
@@ -66,6 +66,32 @@ def _parse_markdown_results(text: str) -> list[dict[str, str]]:
     return [{"title": url, "url": url, "description": ""} for url in dict.fromkeys(urls)]
 
 
+def _parse_subdomain_catalog(text: str) -> list[dict[str, str]]:
+    """Parse get_sub_domains markdown headings like `### security.vuln`."""
+    results: list[dict[str, str]] = []
+    current: dict[str, str] | None = None
+    for line in text.splitlines():
+        heading = re.match(r"^###\s+([A-Za-z0-9][A-Za-z0-9_.-]*)\s*$", line)
+        if heading:
+            if current:
+                results.append(current)
+            current = {
+                "title": heading.group(1).strip(),
+                "url": "",
+                "description": "",
+                "evidence_type": "sub_domain",
+            }
+            continue
+        if current is None:
+            continue
+        if line.strip() and not line.startswith("#"):
+            description = current.get("description", "")
+            current["description"] = (description + " " + line.strip()).strip()
+    if current:
+        results.append(current)
+    return results
+
+
 def _split_domain(domain: str, sub_domain: str = "") -> tuple[str, str]:
     if sub_domain or "." not in domain:
         return domain, sub_domain
@@ -75,6 +101,56 @@ def _split_domain(domain: str, sub_domain: str = "") -> tuple[str, str]:
 
 def _batch_query_object(query: str, max_results: int) -> dict[str, Any]:
     return {"query": query, "max_results": max_results}
+
+
+def parse_sub_domain_params(
+    raw_json: str = "",
+    key_values: list[str] | None = None,
+) -> dict[str, Any]:
+    """Parse `--sub-domain-params JSON` and repeatable `--param key=value`."""
+    params: dict[str, Any] = {}
+    raw = (raw_json or "").strip()
+    if raw:
+        try:
+            parsed = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"invalid --sub-domain-params JSON: {exc}") from exc
+        if not isinstance(parsed, dict):
+            raise ValueError("--sub-domain-params must be a JSON object")
+        params.update(parsed)
+    for item in key_values or []:
+        token = (item or "").strip()
+        if not token or "=" not in token:
+            raise ValueError(f"invalid --param value (expected key=value): {item!r}")
+        key, value = token.split("=", 1)
+        key = key.strip()
+        if not key:
+            raise ValueError(f"invalid --param value (empty key): {item!r}")
+        params[key] = value
+    return params
+
+
+# Current AnySearch MCP get_sub_domains enum. Empty CLI calls return this local catalog
+# because the live tool requires domain/domains.
+ANYSEARCH_TOP_LEVEL_DOMAINS = (
+    "general",
+    "resource",
+    "social_media",
+    "finance",
+    "academic",
+    "legal",
+    "health",
+    "business",
+    "security",
+    "ip",
+    "code",
+    "energy",
+    "environment",
+    "agriculture",
+    "travel",
+    "film",
+    "gaming",
+)
 
 
 class AnySearchProvider(BaseSearchProvider):
@@ -88,9 +164,46 @@ class AnySearchProvider(BaseSearchProvider):
     async def search(self, query: str, max_results: int = 5) -> str:
         return await self.call_tool("search", {"query": query, "max_results": max_results})
 
+    def _local_domain_catalog(self) -> str:
+        """Return top-level domains without a network call when no domain is given."""
+        results = [
+            {
+                "title": domain,
+                "url": "",
+                "description": f"AnySearch vertical domain: {domain}",
+            }
+            for domain in ANYSEARCH_TOP_LEVEL_DOMAINS
+        ]
+        lines = ["## AnySearch Domains", ""]
+        lines.extend(f"- `{domain}`" for domain in ANYSEARCH_TOP_LEVEL_DOMAINS)
+        lines.append("")
+        lines.append(
+            "Pass a domain to `anysearch-domains <domain>` for sub_domain details via get_sub_domains."
+        )
+        content = "\n".join(lines)
+        return json.dumps(
+            {
+                "ok": True,
+                "provider": "anysearch",
+                "tool": "get_sub_domains",
+                "content": content,
+                "raw_content": content,
+                "results": results,
+                "total": len(results),
+                "elapsed_ms": 0,
+                "source": "local_catalog",
+            },
+            ensure_ascii=False,
+            indent=2,
+        )
+
     async def list_domains(self, domain: str = "") -> str:
-        arguments = {"domain": domain} if domain else {}
-        return await self.call_tool("list_domains", arguments)
+        # Live AnySearch MCP renamed list_domains -> get_sub_domains.
+        domain = (domain or "").strip()
+        if not domain:
+            return self._local_domain_catalog()
+        parent, _child = _split_domain(domain, "")
+        return await self.call_tool("get_sub_domains", {"domains": [parent]})
 
     async def vertical_search(
         self,
@@ -98,6 +211,7 @@ class AnySearchProvider(BaseSearchProvider):
         domain: str = "",
         sub_domain: str = "",
         max_results: int = 5,
+        sub_domain_params: dict[str, Any] | None = None,
     ) -> str:
         arguments: dict[str, Any] = {"query": query, "max_results": max_results}
         domain, sub_domain = _split_domain(domain, sub_domain)
@@ -105,10 +219,34 @@ class AnySearchProvider(BaseSearchProvider):
             arguments["domain"] = domain
         if sub_domain:
             arguments["sub_domain"] = sub_domain
+        if sub_domain_params:
+            arguments["sub_domain_params"] = sub_domain_params
         return await self.call_tool("search", arguments)
 
     async def extract(self, url: str, max_length: int = 20000) -> str:
-        return await self.call_tool("extract", {"url": url, "max_length": max_length})
+        # Live extract schema only accepts `url`; truncate locally when requested.
+        raw = await self.call_tool("extract", {"url": url})
+        if max_length is None or max_length <= 0:
+            return raw
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError:
+            return raw
+        if not data.get("ok"):
+            return raw
+        for key in ("content", "raw_content"):
+            value = data.get(key)
+            if isinstance(value, str) and len(value) > max_length:
+                data[key] = value[:max_length]
+        for item in data.get("results") or []:
+            if not isinstance(item, dict):
+                continue
+            for key in ("description", "raw_content"):
+                value = item.get(key)
+                if isinstance(value, str) and len(value) > max_length:
+                    item[key] = value[:max_length]
+        data["max_length"] = max_length
+        return json.dumps(data, ensure_ascii=False, indent=2)
 
     async def batch_search(self, queries: list[str], max_results: int = 3) -> str:
         if len(queries) > 5:
@@ -177,6 +315,10 @@ class AnySearchProvider(BaseSearchProvider):
         text = _extract_text(result)
         is_error = bool(result.get("isError"))
         parsed_results = [] if is_error else _parse_markdown_results(text)
+        if name == "get_sub_domains" and not is_error:
+            catalog = _parse_subdomain_catalog(text)
+            if catalog:
+                parsed_results = catalog
         if text and not is_error and not parsed_results:
             parsed_results = [
                 {
@@ -200,6 +342,10 @@ class AnySearchProvider(BaseSearchProvider):
         for key in ("query", "domain", "sub_domain", "url"):
             if arguments.get(key):
                 output[key] = arguments[key]
+        if arguments.get("domains"):
+            output["domains"] = arguments["domains"]
+        if arguments.get("sub_domain_params"):
+            output["sub_domain_params"] = arguments["sub_domain_params"]
         if is_error:
             output["error_type"] = "provider_error"
             output["error"] = text or "AnySearch tool returned isError=true"

--- a/src/smart_search/service.py
+++ b/src/smart_search/service.py
@@ -3023,13 +3023,20 @@ async def anysearch_domains(domain: str = "") -> dict[str, Any]:
     return await _decode_provider_json(await _anysearch_provider().list_domains(domain))
 
 
-async def anysearch_search(query: str, domain: str = "", sub_domain: str = "", max_results: int = 5) -> dict[str, Any]:
+async def anysearch_search(
+    query: str,
+    domain: str = "",
+    sub_domain: str = "",
+    max_results: int = 5,
+    sub_domain_params: dict[str, Any] | None = None,
+) -> dict[str, Any]:
     return await _decode_provider_json(
         await _anysearch_provider().vertical_search(
             query=query,
             domain=domain,
             sub_domain=sub_domain,
             max_results=max_results,
+            sub_domain_params=sub_domain_params,
         )
     )
 

--- a/tests/test_anysearch_provider.py
+++ b/tests/test_anysearch_provider.py
@@ -3,7 +3,11 @@ import json
 import httpx
 import pytest
 
-from smart_search.providers.anysearch import AnySearchProvider
+from smart_search.providers.anysearch import (
+    ANYSEARCH_TOP_LEVEL_DOMAINS,
+    AnySearchProvider,
+    parse_sub_domain_params,
+)
 
 
 class FakeAnySearchClient:
@@ -81,16 +85,127 @@ async def test_anysearch_jsonrpc_success_parses_markdown_and_auth_header(monkeyp
 async def test_anysearch_anonymous_request_omits_authorization(monkeypatch):
     FakeAnySearchClient.response = httpx.Response(
         200,
-        json={"jsonrpc": "2.0", "id": 1, "result": {"content": [{"type": "text", "text": "No domains"}]}},
+        json={
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "## security Domain Capabilities\n\n### security.vuln\nCVE lookup",
+                    }
+                ]
+            },
+        },
         request=httpx.Request("POST", "https://api.anysearch.com/mcp"),
     )
     monkeypatch.setattr("smart_search.providers.anysearch.httpx.AsyncClient", FakeAnySearchClient)
 
     provider = AnySearchProvider("https://api.anysearch.com/mcp", None)
+    data = json.loads(await provider.list_domains("security"))
+
+    assert data["ok"] is True
+    assert data["tool"] == "get_sub_domains"
+    assert FakeAnySearchClient.calls[0]["json"]["params"]["name"] == "get_sub_domains"
+    assert FakeAnySearchClient.calls[0]["json"]["params"]["arguments"] == {"domains": ["security"]}
+    assert "Authorization" not in FakeAnySearchClient.calls[0]["headers"]
+    assert data["results"][0]["title"] == "security.vuln"
+
+
+@pytest.mark.asyncio
+async def test_anysearch_list_domains_without_domain_returns_local_catalog(monkeypatch):
+    monkeypatch.setattr("smart_search.providers.anysearch.httpx.AsyncClient", FakeAnySearchClient)
+
+    provider = AnySearchProvider("https://api.anysearch.com/mcp", "as-test-secret")
     data = json.loads(await provider.list_domains())
 
     assert data["ok"] is True
-    assert "Authorization" not in FakeAnySearchClient.calls[0]["headers"]
+    assert data["tool"] == "get_sub_domains"
+    assert data["source"] == "local_catalog"
+    assert data["total"] == len(ANYSEARCH_TOP_LEVEL_DOMAINS)
+    assert FakeAnySearchClient.calls == []
+
+
+@pytest.mark.asyncio
+async def test_anysearch_list_domains_dotted_shorthand_uses_parent(monkeypatch):
+    FakeAnySearchClient.response = httpx.Response(
+        200,
+        json={
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {"content": [{"type": "text", "text": "### security.vuln\nCVE details"}]},
+        },
+        request=httpx.Request("POST", "https://api.anysearch.com/mcp"),
+    )
+    monkeypatch.setattr("smart_search.providers.anysearch.httpx.AsyncClient", FakeAnySearchClient)
+
+    provider = AnySearchProvider("https://api.anysearch.com/mcp", "as-test-secret")
+    data = json.loads(await provider.list_domains("security.cve"))
+
+    assert data["ok"] is True
+    assert FakeAnySearchClient.calls[0]["json"]["params"]["arguments"] == {"domains": ["security"]}
+
+
+@pytest.mark.asyncio
+async def test_anysearch_vertical_search_sends_sub_domain_params(monkeypatch):
+    FakeAnySearchClient.response = httpx.Response(
+        200,
+        json={
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {"content": [{"type": "text", "text": "CVE-2024-3094 severity: critical"}]},
+        },
+        request=httpx.Request("POST", "https://api.anysearch.com/mcp"),
+    )
+    monkeypatch.setattr("smart_search.providers.anysearch.httpx.AsyncClient", FakeAnySearchClient)
+
+    provider = AnySearchProvider("https://api.anysearch.com/mcp", "as-test-secret")
+    params = {"type": "cve", "value": "CVE-2024-3094"}
+    data = json.loads(
+        await provider.vertical_search(
+            "CVE-2024-3094",
+            domain="security",
+            sub_domain="security.vuln",
+            max_results=2,
+            sub_domain_params=params,
+        )
+    )
+
+    assert data["ok"] is True
+    assert data["sub_domain_params"] == params
+    assert FakeAnySearchClient.calls[0]["json"]["params"]["arguments"]["sub_domain_params"] == params
+
+
+@pytest.mark.asyncio
+async def test_anysearch_extract_omits_max_length_and_truncates_locally(monkeypatch):
+    FakeAnySearchClient.response = httpx.Response(
+        200,
+        json={
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {"content": [{"type": "text", "text": "ABCDEFGHIJKLMNOPQRSTUVWXYZ"}]},
+        },
+        request=httpx.Request("POST", "https://api.anysearch.com/mcp"),
+    )
+    monkeypatch.setattr("smart_search.providers.anysearch.httpx.AsyncClient", FakeAnySearchClient)
+
+    provider = AnySearchProvider("https://api.anysearch.com/mcp", "as-test-secret")
+    data = json.loads(await provider.extract("https://example.com", max_length=10))
+
+    assert data["ok"] is True
+    assert FakeAnySearchClient.calls[0]["json"]["params"]["arguments"] == {"url": "https://example.com"}
+    assert data["content"] == "ABCDEFGHIJ"
+    assert data["max_length"] == 10
+
+
+def test_parse_sub_domain_params_merges_json_and_key_values():
+    params = parse_sub_domain_params('{"type":"cve"}', ["value=CVE-2024-3094", "extra=1"])
+    assert params == {"type": "cve", "value": "CVE-2024-3094", "extra": "1"}
+
+
+def test_parse_sub_domain_params_rejects_invalid_json():
+    with pytest.raises(ValueError, match="invalid --sub-domain-params JSON"):
+        parse_sub_domain_params("{bad", [])
 
 
 @pytest.mark.asyncio

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2511,10 +2511,10 @@ def test_anysearch_commands_use_service_wrappers(monkeypatch, capsys):
 
     async def fake_domains(domain=""):
         calls.append(("domains", domain))
-        return {"ok": True, "provider": "anysearch", "tool": "list_domains", "results": []}
+        return {"ok": True, "provider": "anysearch", "tool": "get_sub_domains", "results": []}
 
-    async def fake_search(query, domain="", sub_domain="", max_results=5):
-        calls.append(("search", query, domain, sub_domain, max_results))
+    async def fake_search(query, domain="", sub_domain="", max_results=5, sub_domain_params=None):
+        calls.append(("search", query, domain, sub_domain, max_results, sub_domain_params))
         return {"ok": True, "provider": "anysearch", "tool": "search", "query": query, "results": []}
 
     async def fake_extract(url, max_length=20000):
@@ -2531,9 +2531,27 @@ def test_anysearch_commands_use_service_wrappers(monkeypatch, capsys):
     monkeypatch.setattr(cli.service, "anysearch_batch", fake_batch)
 
     assert cli.main(["anysearch-domains", "security"]) == cli.EXIT_OK
-    assert json.loads(capsys.readouterr().out)["tool"] == "list_domains"
-    assert cli.main(["as", "CVE-2024-3094", "--domain", "security.cve", "--sub-domain", "xz", "--max-results", "2"]) == cli.EXIT_OK
+    assert json.loads(capsys.readouterr().out)["tool"] == "get_sub_domains"
+    assert (
+        cli.main(
+            [
+                "as",
+                "CVE-2024-3094",
+                "--domain",
+                "security",
+                "--sub-domain",
+                "security.vuln",
+                "--sub-domain-params",
+                '{"type":"cve","value":"CVE-2024-3094"}',
+                "--max-results",
+                "2",
+            ]
+        )
+        == cli.EXIT_OK
+    )
     assert json.loads(capsys.readouterr().out)["query"] == "CVE-2024-3094"
+    assert cli.main(["as", "query", "--param", "type=cve", "--param", "value=CVE-1"]) == cli.EXIT_OK
+    assert json.loads(capsys.readouterr().out)["query"] == "query"
     assert cli.main(["as-extract", "https://example.com", "--max-length", "123"]) == cli.EXIT_OK
     assert json.loads(capsys.readouterr().out)["url"] == "https://example.com"
     assert cli.main(["as-batch", "a", "b", "--max-results", "1"]) == cli.EXIT_OK
@@ -2541,10 +2559,29 @@ def test_anysearch_commands_use_service_wrappers(monkeypatch, capsys):
 
     assert calls == [
         ("domains", "security"),
-        ("search", "CVE-2024-3094", "security.cve", "xz", 2),
+        (
+            "search",
+            "CVE-2024-3094",
+            "security",
+            "security.vuln",
+            2,
+            {"type": "cve", "value": "CVE-2024-3094"},
+        ),
+        ("search", "query", "", "", 5, {"type": "cve", "value": "CVE-1"}),
         ("extract", "https://example.com", 123),
         ("batch", ["a", "b"], 1),
     ]
+
+
+def test_anysearch_search_rejects_invalid_sub_domain_params(monkeypatch, capsys):
+    async def fake_search(*args, **kwargs):
+        raise AssertionError("service should not be called for invalid params")
+
+    monkeypatch.setattr(cli.service, "anysearch_search", fake_search)
+    assert cli.main(["as", "query", "--sub-domain-params", "{bad"]) == cli.EXIT_PARAMETER_ERROR
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is False
+    assert payload["error_type"] == "parameter_error"
 
 
 def test_zhipu_mcp_commands_use_service_wrappers(monkeypatch, capsys):

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1727,10 +1727,10 @@ async def test_anysearch_service_wrappers_decode_provider_json(monkeypatch):
 
         async def list_domains(self, domain=""):
             calls.append(("domains", domain))
-            return json.dumps({"ok": True, "provider": "anysearch", "tool": "list_domains", "domain": domain})
+            return json.dumps({"ok": True, "provider": "anysearch", "tool": "get_sub_domains", "domain": domain})
 
-        async def vertical_search(self, query, domain="", sub_domain="", max_results=5):
-            calls.append(("search", query, domain, sub_domain, max_results))
+        async def vertical_search(self, query, domain="", sub_domain="", max_results=5, sub_domain_params=None):
+            calls.append(("search", query, domain, sub_domain, max_results, sub_domain_params))
             return json.dumps({"ok": True, "provider": "anysearch", "tool": "search", "query": query})
 
         async def extract(self, url, max_length=20000):
@@ -1747,11 +1747,17 @@ async def test_anysearch_service_wrappers_decode_provider_json(monkeypatch):
     monkeypatch.setattr(service, "AnySearchProvider", FakeAnySearchProvider)
 
     domains = await service.anysearch_domains("security")
-    search = await service.anysearch_search("CVE-2024-3094", domain="security.cve", sub_domain="xz", max_results=2)
+    search = await service.anysearch_search(
+        "CVE-2024-3094",
+        domain="security.cve",
+        sub_domain="xz",
+        max_results=2,
+        sub_domain_params={"type": "cve", "value": "CVE-2024-3094"},
+    )
     extract = await service.anysearch_extract("https://example.com", max_length=123)
     batch = await service.anysearch_batch(["a", "b"], max_results=1)
 
-    assert domains["tool"] == "list_domains"
+    assert domains["tool"] == "get_sub_domains"
     assert search["query"] == "CVE-2024-3094"
     assert extract["url"] == "https://example.com"
     assert batch["tool"] == "batch_search"
@@ -1759,7 +1765,7 @@ async def test_anysearch_service_wrappers_decode_provider_json(monkeypatch):
         ("init", "https://anysearch.example.com/mcp", "as-test-secret", 7.0),
         ("domains", "security"),
         ("init", "https://anysearch.example.com/mcp", "as-test-secret", 7.0),
-        ("search", "CVE-2024-3094", "security.cve", "xz", 2),
+        ("search", "CVE-2024-3094", "security.cve", "xz", 2, {"type": "cve", "value": "CVE-2024-3094"}),
         ("init", "https://anysearch.example.com/mcp", "as-test-secret", 7.0),
         ("extract", "https://example.com", 123),
         ("init", "https://anysearch.example.com/mcp", "as-test-secret", 7.0),


### PR DESCRIPTION
## Summary
- Map `anysearch-domains` to live AnySearch MCP tool `get_sub_domains` (replacing removed `list_domains`)
- Return a local top-level domain catalog when no domain is provided, since the live tool requires `domain`/`domains`
- Add structured vertical params via `--sub-domain-params JSON` and repeatable `--param KEY=VALUE`
- Stop sending unsupported `max_length` to live `extract`; keep CLI `--max-length` as local truncation
- Improve subdomain catalog parsing (`### security.vuln` headings) and update docs/tests

## Test plan
- [x] `pytest tests/test_anysearch_provider.py`
- [x] `pytest tests/test_cli.py::test_anysearch_commands_use_service_wrappers`
- [x] `pytest tests/test_cli.py::test_anysearch_search_rejects_invalid_sub_domain_params`
- [x] `pytest tests/test_service.py::test_anysearch_service_wrappers_decode_provider_json`
- [x] `pytest tests/test_regression.py::test_streaming_and_anysearch_contract_public_and_packaged_assets_match`
- [ ] Live check: `smart-search anysearch-domains security --format json`
- [ ] Live check: `smart-search anysearch-search "CVE-2024-3094" --domain security --sub-domain security.vuln --param type=cve --param value=CVE-2024-3094 --format json`


Made with [Cursor](https://cursor.com)