### PR TITLE
fix(xai-responses): extract sources from inline URLs when annotations are missing

### DIFF
--- a/src/smart_search/providers/xai_responses.py
+++ b/src/smart_search/providers/xai_responses.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import re
 from typing import Any
 
 import httpx
@@ -110,8 +111,27 @@ class XAIResponsesSearchProvider(BaseSearchProvider):
                     sources.append(source)
 
         answer = "\n\n".join(part.strip() for part in text_parts if part.strip()).strip()
+        if not sources and answer:
+            sources = self._extract_inline_urls(answer)
         if sources:
             answer = f"{answer}\n\nsources({json.dumps(sources, ensure_ascii=False)})".strip()
 
         await log_info(ctx, f"content: {answer}", config.debug_enabled)
         return answer
+
+    @staticmethod
+    def _extract_inline_urls(text: str) -> list[dict[str, str]]:
+        """Extract source URLs inlined in answer text when the provider returns no url_citation annotations.
+
+        Some Responses-compatible providers (e.g. OpenCode Go) return citations as markdown
+        links inside output_text instead of structured annotations.
+        """
+        sources: list[dict[str, str]] = []
+        seen: set[str] = set()
+        for match in re.finditer(r"(https?://[^\s)\]>]+)", text):
+            url = match.group(1).rstrip(".,;:，。；：")
+            if not url or url in seen:
+                continue
+            seen.add(url)
+            sources.append({"url": url})
+        return sources


### PR DESCRIPTION
# fix(xai-responses): extract sources from inline URLs when annotations are missing

## Problem

The `xai-responses` provider (`/responses` endpoint) currently extracts source URLs **only** from structured `url_citation` annotations:

```python
for annotation in content.get("annotations", []) or []:
    if not isinstance(annotation, dict) or annotation.get("type") != "url_citation":
        continue
    ...
```

However, an increasing number of Responses-API-compatible gateways/providers (e.g. OpenCode Go's `deepseek-v4-flash`, and other Zen-style relays) do **not** return `url_citation` annotations. They return citations as **markdown links inlined in the `output_text`** instead.

**Result**: `search` succeeds and returns rich content with inline source links, but `primary_sources` / `sources_count` are always `0` — the sources pipeline (`split_answer_and_sources` in `sources.py`) receives no `sources(...)` block, so downstream evidence tracking, citation display, and `fetch_before_claim` workflows silently lose all source URLs.

## Fix

When no `url_citation` annotations are found, fall back to extracting source URLs from the answer text itself:

- Extract `http(s)://` URLs inlined in `output_text` (markdown links, bare URLs)
- Deduplicate
- Strip trailing punctuation (both ASCII and CJK: `.,;:，。；：`)

This mirrors the existing pattern already used elsewhere in the codebase (`zhipu_mcp.py`, `anysearch.py` use `re.findall(r"https?://[^\s)>\]]+", text)` for the same purpose).

## Validation

Unit tests (all passing):

```python
# markdown link + bare URL
_extract_inline_urls('据 [TokenPost](http://www.tokenpost.kr/news/briefing/388583) 报道... https://tw.tokenpost.com/news/blockchain/32389')
# -> 2 sources

# dedup
_extract_inline_urls('https://example.com/a 和 https://example.com/a')
# -> 1 source

# no URL
_extract_inline_urls('纯文本没有链接')  # -> []

# CJK trailing punctuation
_extract_inline_urls('来源 https://example.com/page。')  # -> ['https://example.com/page']
```

End-to-end with OpenCode Go (`deepseek-v4-flash` via Responses API + `web_search` tool):

```json
{
  "ok": true,
  "primary_sources_count": 35,
  "primary_sources": [
    {"url": "https://ir.apollo.com/news-events/press-releases/detail/642/..."},
    {"url": "https://www.cnbc.com/2026/08/10/nvidia-wall-street-asset-managers-500-billion-ai-push.html"},
    ...
  ]
}
```

## Notes

- Behavior is unchanged when `url_citation` annotations **are** present (fallback only triggers when `sources` is empty)
- The `[[N]](url)` citation format handled by `_extract_inline_citation_sources` in `sources.py` is unaffected
