### PR TITLE
fix(sciverse): align meta-search/agentic-search payloads with current API schema

### DIFF
--- a/src/smart_search/cli.py
+++ b/src/smart_search/cli.py
@@ -2580,7 +2580,7 @@ async def _run_async(args: argparse.Namespace) -> int:
         data = await service.sciverse_semantic(
             args.query,
             top_k=args.top_k,
-            mode=args.mode,
+            retrieval=args.retrieval,
             source_types=args.source_types,
         )
         return _print_result("sciverse-semantic", data, args.format, args.output)
@@ -3088,7 +3088,7 @@ def build_parser() -> argparse.ArgumentParser:
     sciverse_semantic_parser.set_defaults(command="sciverse-semantic")
     sciverse_semantic_parser.add_argument("query")
     sciverse_semantic_parser.add_argument("--top-k", type=int, default=10)
-    sciverse_semantic_parser.add_argument("--mode", choices=["fast", "balanced", "quality"], default="balanced")
+    sciverse_semantic_parser.add_argument("--retrieval", choices=["hybrid", "milvus", "es"], default="")
     sciverse_semantic_parser.add_argument("--source-types", default="", help="Comma-separated Sciverse source types.")
     _add_format_args(sciverse_semantic_parser)
 

--- a/src/smart_search/providers/sciverse.py
+++ b/src/smart_search/providers/sciverse.py
@@ -65,6 +65,61 @@ def _split_csv(values: list[str] | str | None) -> list[str]:
     return [str(item).strip() for item in values if str(item).strip()]
 
 
+_SORT_ORDER_MAP = {
+    "SORT_ORDER_DESC": "SORT_ORDER_DESC",
+    "SORT_ORDER_ASC": "SORT_ORDER_ASC",
+    "desc": "SORT_ORDER_DESC",
+    "asc": "SORT_ORDER_ASC",
+}
+
+
+def _normalize_sort_item(item: dict[str, Any]) -> dict[str, Any] | None:
+    if not isinstance(item, dict) or not item.get("field"):
+        return None
+    raw_order = str(item.get("order") or "SORT_ORDER_DESC")
+    normalized = dict(item)
+    normalized["order"] = _SORT_ORDER_MAP.get(raw_order.lower(), _SORT_ORDER_MAP.get(raw_order, "SORT_ORDER_DESC"))
+    return normalized
+
+
+def _build_meta_search_sort(sort_by_year: str, extra_sort: list[dict[str, Any]] | None) -> list[dict[str, Any]]:
+    sort_items: list[dict[str, Any]] = []
+    direction = (sort_by_year or "none").lower()
+    if direction in ("desc", "asc"):
+        sort_items.append({"field": "publication_published_year", "order": _SORT_ORDER_MAP[direction]})
+    for item in extra_sort or []:
+        normalized = _normalize_sort_item(item)
+        if normalized:
+            sort_items.append(normalized)
+    return sort_items
+
+
+def _build_meta_search_filters(
+    *,
+    authors: list[str] | str | None = None,
+    journals: list[str] | str | None = None,
+    subjects: list[str] | str | None = None,
+    year_from: int | None = None,
+    year_to: int | None = None,
+    extra_filters: list[dict[str, Any]] | None = None,
+) -> list[dict[str, Any]]:
+    filters: list[dict[str, Any]] = []
+    if _split_csv(authors):
+        filters.append({"field": "author", "operator": "FILTER_OP_IN", "value": _split_csv(authors)})
+    for journal in _split_csv(journals):
+        filters.append({"field": "publication_venue_name_unified", "operator": "FILTER_OP_MATCH", "value": journal})
+    if _split_csv(subjects):
+        filters.append({"field": "subjects", "operator": "FILTER_OP_IN", "value": _split_csv(subjects)})
+    if year_from is not None:
+        filters.append({"field": "publication_published_year", "operator": "FILTER_OP_GTE", "value": year_from})
+    if year_to is not None:
+        filters.append({"field": "publication_published_year", "operator": "FILTER_OP_LTE", "value": year_to})
+    for item in extra_filters or []:
+        if isinstance(item, dict) and item.get("field"):
+            filters.append(item)
+    return filters
+
+
 def _compact_payload(payload: dict[str, Any]) -> dict[str, Any]:
     return {key: value for key, value in payload.items() if value not in (None, "", [], {})}
 
@@ -163,20 +218,22 @@ class SciverseProvider(BaseSearchProvider):
             return _parameter_error("search_papers", "page must be >= 1", query=query)
         if page_size < 1 or page_size > 50:
             return _parameter_error("search_papers", f"page_size must be between 1 and 50, got {page_size}", query=query)
+        filters = _build_meta_search_filters(
+            authors=authors,
+            journals=journals,
+            subjects=subjects,
+            year_from=year_from,
+            year_to=year_to,
+            extra_filters=filters_advanced,
+        )
+        sort = _build_meta_search_sort(sort_by_year=sort_by_year, extra_sort=sort_advanced)
+        effective_query = " ".join(part for part in (query, title_contains, abstract_contains) if part).strip()
         payload = _compact_payload(
             {
                 "collection": collection or "papers",
-                "query": query,
-                "title_contains": title_contains,
-                "abstract_contains": abstract_contains,
-                "authors": _split_csv(authors),
-                "journals": _split_csv(journals),
-                "subjects": _split_csv(subjects),
-                "year_from": year_from,
-                "year_to": year_to,
-                "filters_advanced": filters_advanced or [],
-                "sort_advanced": sort_advanced or [],
-                "sort_by_year": sort_by_year,
+                "query": effective_query,
+                "filters": filters,
+                "sort": sort,
                 "freshness_boost": freshness_boost,
                 "page": page,
                 "page_size": page_size,
@@ -188,7 +245,7 @@ class SciverseProvider(BaseSearchProvider):
         self,
         query: str,
         top_k: int = 10,
-        mode: str = "balanced",
+        retrieval: str = "",
         source_types: list[str] | str | None = None,
     ) -> str:
         if not self.api_key:
@@ -199,7 +256,7 @@ class SciverseProvider(BaseSearchProvider):
             {
                 "query": query,
                 "top_k": top_k,
-                "mode": mode or "balanced",
+                "retrieval": retrieval,
                 "source_types": _split_csv(source_types),
             }
         )

--- a/src/smart_search/service.py
+++ b/src/smart_search/service.py
@@ -3342,11 +3342,11 @@ async def sciverse_search(
 async def sciverse_semantic(
     query: str,
     top_k: int = 10,
-    mode: str = "balanced",
+    retrieval: str = "",
     source_types: list[str] | str | None = None,
 ) -> dict[str, Any]:
     return await _decode_provider_json(
-        await _sciverse_provider().semantic_search(query=query, top_k=top_k, mode=mode, source_types=source_types),
+        await _sciverse_provider().semantic_search(query=query, top_k=top_k, retrieval=retrieval, source_types=source_types),
         provider="sciverse",
     )
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2719,8 +2719,8 @@ def test_sciverse_commands_use_service_wrappers(monkeypatch, capsys):
         calls.append(("search", kwargs))
         return {"ok": True, "provider": "sciverse", "tool": "search_papers", "query": kwargs.get("query"), "results": []}
 
-    async def fake_semantic(query, top_k=10, mode="balanced", source_types=""):
-        calls.append(("semantic", query, top_k, mode, source_types))
+    async def fake_semantic(query, top_k=10, retrieval="", source_types=""):
+        calls.append(("semantic", query, top_k, retrieval, source_types))
         return {"ok": True, "provider": "sciverse", "tool": "semantic_search", "query": query, "hits": []}
 
     async def fake_read(doc_id, offset=0, limit=4096):
@@ -2757,7 +2757,7 @@ def test_sciverse_commands_use_service_wrappers(monkeypatch, capsys):
         == cli.EXIT_OK
     )
     assert json.loads(capsys.readouterr().out)["query"] == "transformer retrieval"
-    assert cli.main(["sv-semantic", "attention mechanism", "--top-k", "3", "--mode", "balanced", "--source-types", "paper,abstract"]) == cli.EXIT_OK
+    assert cli.main(["sv-semantic", "attention mechanism", "--top-k", "3", "--retrieval", "hybrid", "--source-types", "paper,abstract"]) == cli.EXIT_OK
     assert json.loads(capsys.readouterr().out)["tool"] == "semantic_search"
     assert cli.main(["sv-read", "doc-1", "--offset", "10", "--limit", "100"]) == cli.EXIT_OK
     assert json.loads(capsys.readouterr().out)["doc_id"] == "doc-1"
@@ -2786,7 +2786,7 @@ def test_sciverse_commands_use_service_wrappers(monkeypatch, capsys):
                 "page_size": 5,
             },
         ),
-        ("semantic", "attention mechanism", 3, "balanced", "paper,abstract"),
+        ("semantic", "attention mechanism", 3, "hybrid", "paper,abstract"),
         ("read", "doc-1", 10, 100),
         ("relations", "paper-1", "REFERENCES", 2, 25),
     ]

--- a/tests/test_sciverse_provider.py
+++ b/tests/test_sciverse_provider.py
@@ -137,9 +137,14 @@ async def test_sciverse_search_payload_and_pagination(monkeypatch):
     assert data["total_count"] == 1
     payload = FakeSciverseClient.calls[0]["json"]
     assert payload["query"] == "transformer retrieval"
-    assert payload["year_from"] == 2020
-    assert payload["authors"] == ["Ada Lovelace", "Grace Hopper"]
-    assert payload["filters_advanced"] == [{"field": "subjects", "op": "contains", "value": "IR"}]
+    filters_by_field = {}
+    for item in payload["filters"]:
+        filters_by_field.setdefault(item["field"], []).append(item)
+    assert filters_by_field["author"] == [{"field": "author", "operator": "FILTER_OP_IN", "value": ["Ada Lovelace", "Grace Hopper"]}]
+    assert filters_by_field["publication_published_year"] == [
+        {"field": "publication_published_year", "operator": "FILTER_OP_GTE", "value": 2020}
+    ]
+    assert filters_by_field["subjects"] == [{"field": "subjects", "op": "contains", "value": "IR"}]
     assert payload["page_size"] == 5
 
 
@@ -153,7 +158,7 @@ async def test_sciverse_semantic_read_and_relations_normalize_outputs(monkeypatc
         json={"hits": [{"doc_id": "doc-1", "offset": 120, "score": 0.91, "title": "Attention"}]},
         request=httpx.Request("POST", "https://api.sciverse.space/agentic-search"),
     )
-    semantic = json.loads(await provider.semantic_search("attention mechanism", top_k=3, mode="balanced", source_types="paper,abstract"))
+    semantic = json.loads(await provider.semantic_search("attention mechanism", top_k=3, retrieval="hybrid", source_types="paper,abstract"))
 
     FakeSciverseClient.response = httpx.Response(
         200,

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -2149,8 +2149,8 @@ async def test_sciverse_service_wrappers_decode_provider_json(monkeypatch):
             calls.append(("search", kwargs))
             return json.dumps({"ok": True, "provider": "sciverse", "tool": "search_papers", "query": kwargs.get("query")})
 
-        async def semantic_search(self, query, top_k=10, mode="balanced", source_types=None):
-            calls.append(("semantic", query, top_k, mode, source_types))
+        async def semantic_search(self, query, top_k=10, retrieval="", source_types=None):
+            calls.append(("semantic", query, top_k, retrieval, source_types))
             return json.dumps({"ok": True, "provider": "sciverse", "tool": "semantic_search", "query": query})
 
         async def read_content(self, doc_id, offset=0, limit=4096):
@@ -2173,7 +2173,7 @@ async def test_sciverse_service_wrappers_decode_provider_json(monkeypatch):
         filters_advanced=[{"field": "year", "op": ">=", "value": 2020}],
         page_size=5,
     )
-    semantic = await service.sciverse_semantic("attention mechanism", top_k=3, mode="balanced", source_types=["paper"])
+    semantic = await service.sciverse_semantic("attention mechanism", top_k=3, retrieval="hybrid", source_types=["paper"])
     read = await service.sciverse_read("doc-1", offset=10, limit=100)
     relations = await service.sciverse_relations("paper-1", relation="REFERENCES", page=2, page_size=25)
 
@@ -2207,7 +2207,7 @@ async def test_sciverse_service_wrappers_decode_provider_json(monkeypatch):
             },
         ),
         ("init", "https://sciverse.example.com", "sciverse-test-secret", 7.0),
-        ("semantic", "attention mechanism", 3, "balanced", ["paper"]),
+        ("semantic", "attention mechanism", 3, "hybrid", ["paper"]),
         ("init", "https://sciverse.example.com", "sciverse-test-secret", 7.0),
         ("read", "doc-1", 10, 100),
         ("init", "https://sciverse.example.com", "sciverse-test-secret", 7.0),


### PR DESCRIPTION
Fixes #26

## 问题

Sciverse 命令（0.1.15）请求体与 `api.sciverse.space` 当前 OpenAPI schema（v1.0.0，https://sciverse.space/openapi.json）脱节：

- `sciverse-search`：平铺字段（`title_contains`、`sort_by_year` 等）被服务端以 `extra_forbidden` 拒绝（HTTP 400）
- `sciverse-semantic`：`mode` 字段已不存在，schema 为 `retrieval`（hybrid/milvus/es）

## 修复

### `providers/sciverse.py`

- `search_papers()` 改为构造 schema 规范的 `filters[]` / `sort[]` 数组；新增 `_build_meta_search_filters` / `_build_meta_search_sort` 翻译层，公开签名与 CLI 旗标不变
- 两个服务端实测异常（详见 issue #26）做了绕开：
  - `title`/`abstract` contains 并入 `query` 全文（`title` 的 `FILTER_OP_CONTAINS` 服务端恒 0 命中，`abstract` 不可过滤）
  - `journals` 用 `FILTER_OP_MATCH`（`CONTAINS` 恒 0 命中）
- `semantic_search()`：`mode` → `retrieval`

### `cli.py` / `service.py`

- `sv-semantic --mode` → `--retrieval {hybrid,milvus,es}`

## 验证

- 全量测试 `412 passed`（sciverse 相关断言已更新到新 payload 形状）
- 真实 token 实测 `api.sciverse.space`：

```
sciverse-search "" --title-contains "GRPO"      → 3134 hits
sciverse-search "" --journals "NeurIPS"          → 33 hits
sciverse-search "GRPO" --year-from 2025          → 3098 hits（按年降序正确）
sciverse-semantic "GRPO LLM reasoning" --top-k 2 → ok
sciverse-relations / sciverse-read               → ok
```

## 兼容性说明

`--mode` 旗标被 `--retrieval` 取代（原值 fast/balanced/quality 本就被服务端拒绝，无有效用户依赖）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)