### PR TITLE
fix(search): stop starving primary model for fallback

### DIFF
--- a/.trellis/spec/backend/provider-capability-contract.md
+++ b/.trellis/spec/backend/provider-capability-contract.md
@@ -262,6 +262,11 @@ Provider configuration:
   backup model ids for the same OpenAI-compatible route. The list is ordered,
   empty entries are ignored, duplicates and the primary model are skipped, and
   the same model suffix normalization as `OPENAI_COMPATIBLE_MODEL` applies.
+  Model fallback is fail-over after a hard failure, not a time slice. The
+  current candidate must receive the remaining `--timeout` budget even when
+  later fallback models are configured. `doctor` and `diagnose openai-compatible`
+  must warn when a configured fallback id is absent from `/models`, without
+  turning a healthy primary chat path into `ok: false`.
 - `OPENAI_COMPATIBLE_STREAM` is an opt-in relay compatibility switch. It
   defaults to `false`, accepts `true`, `1`, or `yes`, and may be overridden for
   one `search` call with `--stream` or `--no-stream`. `--stream` means prefer
@@ -365,6 +370,8 @@ Main-search peer rule:
   is an exact model diagnostic and disables configured fallback models.
   `--fallback off` disables provider fallback and OpenAI-compatible model
   fallback, but not same-model stream-to-non-stream transport fallback.
+  Configuring fallback models must not cap the primary attempt at 30 seconds
+  or half of the remaining budget.
 - OpenAI-compatible primary model instability is guarded by a process-local
   model breaker keyed by `api_url + model`; two consecutive whole-model
   failures open the breaker for 10 minutes and skip that model in favor of

--- a/README.md
+++ b/README.md
@@ -289,6 +289,7 @@ Important boundaries:
 
 - xAI official live search uses the Responses API `/responses` route through `XAI_*`. Compatible relays and gateways use Chat Completions `/chat/completions` through `OPENAI_COMPATIBLE_*`.
 - `OPENAI_COMPATIBLE_STREAM=true` or `smart-search search --stream` sets `stream=true` only for OpenAI-compatible `search` and provider-side `fetch` calls. It is a relay compatibility switch for long requests and does not change xAI Responses behavior, URL description, or source ranking.
+- `OPENAI_COMPATIBLE_FALLBACK_MODELS` is fail-over, not a time slice. The primary model keeps the remaining `--timeout` budget. A fallback model is tried only after a hard failure such as `model_not_found`, auth, empty content, or a non-retryable protocol error. `doctor` and `diagnose openai-compatible` warn when a configured fallback id is missing from `/models`.
 - Legacy `SMART_SEARCH_API_URL`, `SMART_SEARCH_API_KEY`, `SMART_SEARCH_API_MODE`, `SMART_SEARCH_MODEL`, and `SMART_SEARCH_XAI_TOOLS` are not supported config keys. Use `XAI_*` or `OPENAI_COMPATIBLE_*` explicitly.
 - Do not force xAI `web_search` / `x_search` tools or legacy `search_parameters` into the OpenAI-compatible Chat Completions route.
 - `zhipu-search` support is the Web Search API route, not Zhipu Chat Completions `tools=[web_search]`, not Search Agent, and not the MCP Server.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -298,6 +298,7 @@ smart-search route-calibrate --models "Qwen/Qwen3-Embedding-8B" --format markdow
 
 - xAI 官方联网搜索路线是 Responses API `/responses`，只通过 `XAI_*` 配置。兼容中转/网关走 Chat Completions `/chat/completions`，只通过 `OPENAI_COMPATIBLE_*` 配置。
 - `OPENAI_COMPATIBLE_STREAM=true` 或 `smart-search search --stream` 只会给 OpenAI-compatible 的 `search` 和 provider 侧 `fetch` 设置 `stream=true`。它是中转长请求兼容开关，不改变 xAI Responses、URL 描述和来源排序行为。
+- `OPENAI_COMPATIBLE_FALLBACK_MODELS` 是失败后接力，不是时间片。主模型会用完剩余的 `--timeout`；只有硬失败（例如 `model_not_found`、鉴权失败、空结果、不可重试协议错误）才会换兜底模型。`doctor` 和 `diagnose openai-compatible` 会在兜底模型不在 `/models` 里时给出警告。
 - 旧的 `SMART_SEARCH_API_URL`、`SMART_SEARCH_API_KEY`、`SMART_SEARCH_API_MODE`、`SMART_SEARCH_MODEL`、`SMART_SEARCH_XAI_TOOLS` 不再是受支持配置项。请显式使用 `XAI_*` 或 `OPENAI_COMPATIBLE_*`。
 - 不要给 OpenAI-compatible Chat Completions 中转强塞 xAI 的 `web_search` / `x_search` 工具或旧 `search_parameters`。
 - `zhipu-search` 对应的是智谱 Web Search API，不是 Chat Completions `tools=[web_search]`，不是 Search Agent，也不是 MCP Server。

--- a/skills/smart-search-cli/references/provider-routing.md
+++ b/skills/smart-search-cli/references/provider-routing.md
@@ -135,7 +135,7 @@ OpenAI-compatible streaming:
 - `OPENAI_COMPATIBLE_STREAM` defaults to `false` and accepts `true`, `1`, or `yes` as true.
 - `search --stream` means "prefer stream first"; stream empty/timeout/retryable protocol failures fall back to the same provider/model with `stream=false`.
 - `search --no-stream` forces `stream=false` for the current invocation.
-- `OPENAI_COMPATIBLE_FALLBACK_MODELS` is an optional comma-separated ordered list. It is tried only after the primary OpenAI-compatible model fails, and `--fallback off` or `--model MODEL` disables this model fallback for the invocation.
+- `OPENAI_COMPATIBLE_FALLBACK_MODELS` is an optional comma-separated ordered list. It is fail-over after a hard primary-model failure, not a time slice. The current candidate keeps the remaining `--timeout` budget; extra fallback models must not shrink that budget. `--fallback off` or `--model MODEL` disables this model fallback for the invocation.
 - OpenAI-compatible attempts may include `model`, `transport`, `fallback_from_transport`, `fallback_from_model`, and `breaker_state`. `transport_fallback_used` records stream-to-non-stream recovery separately from provider/model `fallback_used`.
 - Streaming applies only to OpenAI-compatible `search()` and provider-side `fetch()` calls. `describe_url()` and `rank_sources()` stay non-streaming. xAI Responses behavior is unchanged.
 

--- a/skills/smart-search-cli/references/setup-config.md
+++ b/skills/smart-search-cli/references/setup-config.md
@@ -27,7 +27,7 @@
 - If `smart-search doctor --format json` returns `ok: false`, follow the `error` field's guidance (`smart-search setup` or `smart-search config set KEY VALUE`); do not silently fall back to native web search.
 - `doctor --format markdown` must render a detailed diagnostic report with overall status, active/default/legacy config paths, log path resolution, file-logging status, masked config values with sources, minimum profile, capability status, main-search provider checks, provider connectivity checks, intent router status, embedding threshold/margin metadata, model metadata, and full long error/message detail.
 - Use `smart-search diagnose openai-compatible --format markdown` when `doctor` succeeds but OpenAI-compatible `search` appears to hang, returns a timeout, or differs between `--stream` and `--no-stream`. It is the beginner-facing one-command report for upstream/relay compatibility.
-- `diagnose openai-compatible --format markdown` must render a short copy-pasteable troubleshooting report with masked config, quick chat check, real search-shape `stream=false` and `stream=true` checks, a plain-language summary, and a next command.
+- `diagnose openai-compatible --format markdown` must render a short copy-pasteable troubleshooting report with masked config, quick chat check, real search-shape `stream=false` and `stream=true` checks, fallback-model inventory against `/models`, the remaining-budget timeout policy, a plain-language summary, and a next command.
 
 ## Setup Workflow
 
@@ -67,7 +67,7 @@
 - Use `smart-search setup --non-interactive --jina-key "key"` to let Jina satisfy `web_fetch`; `JINA_RESPOND_WITH=readerlm-v2` also requires `JINA_API_KEY`.
 - Use `smart-search setup --non-interactive --zhipu-mcp-key "key"` only when the user explicitly wants Coding Plan Remote MCP quota.
 - Use `smart-search setup --non-interactive --openai-compatible-stream true` only when an OpenAI-compatible relay benefits from SSE streaming for long requests. Default remains false.
-- Use `smart-search setup --non-interactive --openai-compatible-fallback-models "model-a,model-b"` to save ordered OpenAI-compatible backup models for primary model instability. `--fallback off` and `search --model MODEL` disable this model fallback for one invocation.
+- Use `smart-search setup --non-interactive --openai-compatible-fallback-models "model-a,model-b"` to save ordered OpenAI-compatible backup models for primary model hard failure. These models do not receive a reserved time slice; the primary model keeps the remaining `--timeout`. `--fallback off` and `search --model MODEL` disable this model fallback for one invocation.
 - Use `smart-search setup --non-interactive --anysearch-api-url "https://api.anysearch.com/mcp" --anysearch-key "key"` only for experimental AnySearch acceptance; do not add it to the normal minimum-profile setup.
 - Use `smart-search setup --non-interactive --sciverse-token "key" --sciverse-api-url "https://api.sciverse.space"` only for explicit experimental Sciverse academic commands; do not add it to the normal minimum-profile setup.
 - `TAVILY_API_URL` defaults to `https://api.tavily.com` and only affects Tavily REST calls. It does not proxy Zhipu.

--- a/src/smart_search/assets/skills/smart-search-cli/references/provider-routing.md
+++ b/src/smart_search/assets/skills/smart-search-cli/references/provider-routing.md
@@ -135,7 +135,7 @@ OpenAI-compatible streaming:
 - `OPENAI_COMPATIBLE_STREAM` defaults to `false` and accepts `true`, `1`, or `yes` as true.
 - `search --stream` means "prefer stream first"; stream empty/timeout/retryable protocol failures fall back to the same provider/model with `stream=false`.
 - `search --no-stream` forces `stream=false` for the current invocation.
-- `OPENAI_COMPATIBLE_FALLBACK_MODELS` is an optional comma-separated ordered list. It is tried only after the primary OpenAI-compatible model fails, and `--fallback off` or `--model MODEL` disables this model fallback for the invocation.
+- `OPENAI_COMPATIBLE_FALLBACK_MODELS` is an optional comma-separated ordered list. It is fail-over after a hard primary-model failure, not a time slice. The current candidate keeps the remaining `--timeout` budget; extra fallback models must not shrink that budget. `--fallback off` or `--model MODEL` disables this model fallback for the invocation.
 - OpenAI-compatible attempts may include `model`, `transport`, `fallback_from_transport`, `fallback_from_model`, and `breaker_state`. `transport_fallback_used` records stream-to-non-stream recovery separately from provider/model `fallback_used`.
 - Streaming applies only to OpenAI-compatible `search()` and provider-side `fetch()` calls. `describe_url()` and `rank_sources()` stay non-streaming. xAI Responses behavior is unchanged.
 

--- a/src/smart_search/assets/skills/smart-search-cli/references/setup-config.md
+++ b/src/smart_search/assets/skills/smart-search-cli/references/setup-config.md
@@ -27,7 +27,7 @@
 - If `smart-search doctor --format json` returns `ok: false`, follow the `error` field's guidance (`smart-search setup` or `smart-search config set KEY VALUE`); do not silently fall back to native web search.
 - `doctor --format markdown` must render a detailed diagnostic report with overall status, active/default/legacy config paths, log path resolution, file-logging status, masked config values with sources, minimum profile, capability status, main-search provider checks, provider connectivity checks, intent router status, embedding threshold/margin metadata, model metadata, and full long error/message detail.
 - Use `smart-search diagnose openai-compatible --format markdown` when `doctor` succeeds but OpenAI-compatible `search` appears to hang, returns a timeout, or differs between `--stream` and `--no-stream`. It is the beginner-facing one-command report for upstream/relay compatibility.
-- `diagnose openai-compatible --format markdown` must render a short copy-pasteable troubleshooting report with masked config, quick chat check, real search-shape `stream=false` and `stream=true` checks, a plain-language summary, and a next command.
+- `diagnose openai-compatible --format markdown` must render a short copy-pasteable troubleshooting report with masked config, quick chat check, real search-shape `stream=false` and `stream=true` checks, fallback-model inventory against `/models`, the remaining-budget timeout policy, a plain-language summary, and a next command.
 
 ## Setup Workflow
 
@@ -67,7 +67,7 @@
 - Use `smart-search setup --non-interactive --jina-key "key"` to let Jina satisfy `web_fetch`; `JINA_RESPOND_WITH=readerlm-v2` also requires `JINA_API_KEY`.
 - Use `smart-search setup --non-interactive --zhipu-mcp-key "key"` only when the user explicitly wants Coding Plan Remote MCP quota.
 - Use `smart-search setup --non-interactive --openai-compatible-stream true` only when an OpenAI-compatible relay benefits from SSE streaming for long requests. Default remains false.
-- Use `smart-search setup --non-interactive --openai-compatible-fallback-models "model-a,model-b"` to save ordered OpenAI-compatible backup models for primary model instability. `--fallback off` and `search --model MODEL` disable this model fallback for one invocation.
+- Use `smart-search setup --non-interactive --openai-compatible-fallback-models "model-a,model-b"` to save ordered OpenAI-compatible backup models for primary model hard failure. These models do not receive a reserved time slice; the primary model keeps the remaining `--timeout`. `--fallback off` and `search --model MODEL` disable this model fallback for one invocation.
 - Use `smart-search setup --non-interactive --anysearch-api-url "https://api.anysearch.com/mcp" --anysearch-key "key"` only for experimental AnySearch acceptance; do not add it to the normal minimum-profile setup.
 - Use `smart-search setup --non-interactive --sciverse-token "key" --sciverse-api-url "https://api.sciverse.space"` only for explicit experimental Sciverse academic commands; do not add it to the normal minimum-profile setup.
 - `TAVILY_API_URL` defaults to `https://api.tavily.com` and only affects Tavily REST calls. It does not proxy Zhipu.

--- a/src/smart_search/cli.py
+++ b/src/smart_search/cli.py
@@ -453,6 +453,24 @@ def _format_doctor_markdown(data: dict[str, Any]) -> str:
         lines.extend(["", "## Main Search Providers"])
         lines.extend(_markdown_table(["Provider", "Status", "Latency", "Message"], rows))
         lines.extend(_provider_detail_lines("Provider Details", main_tests))
+    inventory = data.get("openai_compatible_fallback_inventory") or {}
+    if inventory:
+        lines.extend(
+            [
+                "",
+                "## OpenAI-compatible Fallback Models",
+                "",
+                f"- Status: {_status_label(inventory.get('status'))}",
+                f"- Timeout policy: `{inventory.get('timeout_policy', 'remaining_budget')}`",
+                f"- Message: {inventory.get('message', '-')}",
+            ]
+        )
+        fallback_models = inventory.get("fallback_models") or []
+        if fallback_models:
+            lines.append("- Configured: `" + "`, `".join(str(item) for item in fallback_models) + "`")
+        unknown = inventory.get("unknown_fallback_models") or []
+        if unknown:
+            lines.append("- Unknown: `" + "`, `".join(str(item) for item in unknown) + "`")
 
     provider_tests = [
         ("exa", data.get("exa_connection_test") or {}),
@@ -603,7 +621,14 @@ def _format_diagnose_markdown(data: dict[str, Any]) -> str:
         f"Model: `{data.get('model', '')}`",
         f"Configured stream: {_yes_no(data.get('configured_stream'))}",
         f"Timeout: {_format_seconds(float(data.get('timeout_seconds', 0) or 0))} seconds",
+        f"Timeout policy: `{data.get('timeout_policy', 'remaining_budget')}`",
     ]
+    inventory = data.get("fallback_model_inventory") or {}
+    if inventory:
+        lines.append("Fallback models: `" + ", ".join(str(item) for item in (inventory.get("fallback_models") or []) or ["-"]) + "`")
+        unknown = inventory.get("unknown_fallback_models") or []
+        if unknown:
+            lines.append("Unknown fallback models: `" + ", ".join(str(item) for item in unknown) + "`")
     checks = data.get("checks") or []
     if checks:
         rows = []

--- a/src/smart_search/service.py
+++ b/src/smart_search/service.py
@@ -465,25 +465,86 @@ def _remaining_budget_seconds(start: float, timeout_seconds: float | None) -> fl
     return max(0.0, float(timeout_seconds) - (time.time() - start))
 
 
+OPENAI_COMPATIBLE_TIMEOUT_POLICY = "remaining_budget"
+
+
 def _attempt_timeout_seconds(
     search_start: float,
     timeout_seconds: float | None,
-    remaining_candidates: int,
+    remaining_candidates: int | None = None,
 ) -> float | None:
+    """Return the remaining search budget for the current candidate.
+
+    Model fallback is fail-over, not a time slice. Extra candidates must not
+    shrink the active model's timeout. ``remaining_candidates`` is accepted for
+    call-site compatibility and ignored.
+    """
+    del remaining_candidates
     remaining_budget = _remaining_budget_seconds(search_start, timeout_seconds)
     if remaining_budget is None:
         return None
-    if remaining_budget <= 0:
-        return 0.001
-    if remaining_candidates <= 1:
-        return max(0.001, remaining_budget)
-    return max(0.001, min(30.0, remaining_budget / 2.0))
+    return max(0.001, remaining_budget)
+
+
+def _openai_fallback_model_inventory(
+    fallback_models: list[str],
+    available_models: list[str] | None = None,
+    *,
+    primary_model: str = "",
+) -> dict[str, Any]:
+    available = [model for model in (available_models or []) if isinstance(model, str) and model]
+    configured = [model for model in fallback_models if isinstance(model, str) and model]
+    if not configured:
+        return {
+            "status": "not_configured",
+            "message": "未配置 OpenAI-compatible 兜底模型",
+            "fallback_models": [],
+            "available_models": available,
+            "unknown_fallback_models": [],
+            "known_fallback_models": [],
+            "timeout_policy": OPENAI_COMPATIBLE_TIMEOUT_POLICY,
+            "timeout_policy_message": "主模型使用剩余 --timeout 预算；只有硬失败后才接力兜底模型",
+            "primary_model": primary_model,
+        }
+    if not available:
+        return {
+            "status": "skipped",
+            "message": "无法对照 /models 清单，已跳过兜底模型检查",
+            "fallback_models": configured,
+            "available_models": [],
+            "unknown_fallback_models": [],
+            "known_fallback_models": configured,
+            "timeout_policy": OPENAI_COMPATIBLE_TIMEOUT_POLICY,
+            "timeout_policy_message": "主模型使用剩余 --timeout 预算；只有硬失败后才接力兜底模型",
+            "primary_model": primary_model,
+        }
+
+    unknown = [model for model in configured if model not in available]
+    known = [model for model in configured if model in available]
+    if unknown:
+        status = "warning"
+        message = "这些兜底模型不在上游 /models 列表中: " + ", ".join(unknown)
+    else:
+        status = "ok"
+        message = "已配置的兜底模型都在上游 /models 列表中"
+    return {
+        "status": status,
+        "message": message,
+        "fallback_models": configured,
+        "available_models": available,
+        "unknown_fallback_models": unknown,
+        "known_fallback_models": known,
+        "timeout_policy": OPENAI_COMPATIBLE_TIMEOUT_POLICY,
+        "timeout_policy_message": "主模型使用剩余 --timeout 预算；只有硬失败后才接力兜底模型",
+        "primary_model": primary_model,
+    }
 
 
 def _append_openai_transport_attempts(
     provider_attempts: list[dict],
     search_provider: Any,
     candidate_config: dict[str, Any],
+    extra: dict[str, Any] | None = None,
 ) -> bool:
     transport_attempts = getattr(search_provider, "last_transport_attempts", [])
     if candidate_config.get("provider") != "openai-compatible" or not transport_attempts:
@@ -494,6 +555,8 @@ def _append_openai_transport_attempts(
             for key, value in transport_attempt.items()
             if key not in {"status", "error_type", "error", "elapsed_ms", "result_count"}
         }
+        if extra:
+            transport_extra.update(extra)
         if candidate_config.get("fallback_from_model"):
             transport_extra["fallback_from_model"] = candidate_config["fallback_from_model"]
         provider_attempts.append(
@@ -2358,6 +2421,7 @@ async def search(
         "openai_compatible_stream": next((bool(item.get("stream")) for item in selected_main_provider_configs if item["provider"] == "openai-compatible"), False),
         "openai_compatible_models": openai_candidate_models,
         "openai_compatible_model_fallback_enabled": len(openai_candidate_models) > 1,
+        "openai_compatible_timeout_policy": OPENAI_COMPATIBLE_TIMEOUT_POLICY,
     }
 
     provider_attempts: list[dict] = []
@@ -2406,18 +2470,16 @@ async def search(
                         )
                     )
                     continue
-            attempt_timeout = _attempt_timeout_seconds(
-                start,
-                timeout_seconds,
-                total_main_candidates - completed_main_candidates + 1,
-            )
+            attempt_timeout = _attempt_timeout_seconds(start, timeout_seconds)
+            if attempt_timeout is not None:
+                attempt_extra["attempt_timeout_seconds"] = round(attempt_timeout, 3)
             try:
                 if attempt_timeout is not None:
                     candidate_result = await asyncio.wait_for(search_provider.search(query, platform), timeout=attempt_timeout)
                 else:
                     candidate_result = await search_provider.search(query, platform)
                 transport_attempts = getattr(search_provider, "last_transport_attempts", [])
-                if _append_openai_transport_attempts(provider_attempts, search_provider, candidate_config):
+                if _append_openai_transport_attempts(provider_attempts, search_provider, candidate_config, extra=attempt_extra):
                     transport_fallback_used = transport_fallback_used or any(
                         attempt.get("fallback_from_transport") for attempt in transport_attempts
                     )
@@ -2456,7 +2518,7 @@ async def search(
                 error_result = _primary_search_exception_result(start, session_id, query, candidate_config["mode"], search_provider.get_provider_name(), e)
                 last_primary_error = error_result
                 transport_attempts = getattr(search_provider, "last_transport_attempts", [])
-                if _append_openai_transport_attempts(provider_attempts, search_provider, candidate_config):
+                if _append_openai_transport_attempts(provider_attempts, search_provider, candidate_config, extra=attempt_extra):
                     transport_fallback_used = transport_fallback_used or any(
                         attempt.get("fallback_from_transport") for attempt in transport_attempts
                     )
@@ -3820,7 +3882,33 @@ async def diagnose_openai_compatible(timeout_seconds: float = 30.0) -> dict[str,
     stream = await _probe_openai_compatible_search_shape(api_url, api_key, model, stream=True, timeout_seconds=timeout_seconds)
     result["checks"].append(stream)
 
+    available_models: list[str] = []
+    try:
+        available_models = await fetch_available_models(api_url, api_key)
+    except Exception:
+        available_models = []
+    inventory = _openai_fallback_model_inventory(
+        config.openai_compatible_fallback_models,
+        available_models,
+        primary_model=model,
+    )
+    result["checks"].append(
+        {
+            "name": "兜底模型清单",
+            "status": inventory["status"],
+            "message": inventory["message"],
+            "response_time_ms": None,
+            "http_status": None,
+            "content_type": "",
+            "has_content": False,
+        }
+    )
+    result["fallback_model_inventory"] = inventory
+    result["timeout_policy"] = OPENAI_COMPATIBLE_TIMEOUT_POLICY
+
     ok, summary, recommendation = _openai_compatible_diagnosis(quick_check, no_stream, stream)
+    if inventory.get("status") == "warning":
+        recommendation = f"{recommendation} 另外，{inventory['message']}。兜底只在主模型硬失败后接力，不会再把主模型砍成 30 秒。"
     result.update(
         {
             "ok": ok,
@@ -4109,6 +4197,15 @@ async def doctor() -> dict[str, Any]:
     info["minimum_profile_ok"] = minimum.get("ok", False)
     info["minimum_profile_missing"] = minimum.get("missing", [])
     info["intent_router_status"] = intent_router_status()
+    openai_test = (info.get("main_search_connection_tests") or {}).get("openai-compatible") or {}
+    available_models = []
+    if isinstance(openai_test, dict):
+        available_models = openai_test.get("available_models") or (openai_test.get("models_endpoint_test") or {}).get("available_models") or []
+    info["openai_compatible_fallback_inventory"] = _openai_fallback_model_inventory(
+        config.openai_compatible_fallback_models,
+        available_models if isinstance(available_models, list) else [],
+        primary_model=config.openai_compatible_model,
+    )
     main_connection_tests = info.get("main_search_connection_tests") or {}
     main_search_statuses = [item.get("status") for item in main_connection_tests.values() if isinstance(item, dict)]
     primary_test = info.get("primary_connection_test", {})

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -477,3 +477,19 @@ def test_streaming_and_anysearch_contract_public_and_packaged_assets_match():
     ]
     for marker in zh_required_markers:
         assert marker in readme_zh
+
+
+def test_openai_compatible_fallback_is_fail_over_not_time_slice():
+    public_contract = _read_reference_tree(PUBLIC_SKILL_DIR)
+    packaged_contract = _read_reference_tree(PACKAGED_SKILL_DIR)
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    readme_zh = (ROOT / "README.zh-CN.md").read_text(encoding="utf-8")
+    markers = [
+        "fail-over after a hard primary-model failure, not a time slice",
+        "remaining `--timeout` budget",
+    ]
+    for marker in markers:
+        assert marker in public_contract
+        assert marker in packaged_contract
+    assert "fail-over, not a time slice" in readme
+    assert "失败后接力，不是时间片" in readme_zh

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1341,6 +1341,176 @@ async def test_search_model_breaker_skips_primary_model(monkeypatch):
     assert result["provider_attempts"][0]["breaker_state"]["state"] == "open"
 
 
+def test_attempt_timeout_uses_remaining_budget_even_with_multiple_candidates():
+    start = time.time()
+
+    timeout = service._attempt_timeout_seconds(start, 90.0, remaining_candidates=2)
+
+    assert timeout is not None
+    assert 89.0 <= timeout <= 90.0
+
+
+def test_openai_fallback_model_inventory_warns_for_unknown_models():
+    inventory = service._openai_fallback_model_inventory(
+        ["missing-model", "grok-4.6"],
+        ["grok-4.6", "grok-4.5"],
+        primary_model="grok-4.6",
+    )
+
+    assert inventory["status"] == "warning"
+    assert inventory["unknown_fallback_models"] == ["missing-model"]
+    assert inventory["known_fallback_models"] == ["grok-4.6"]
+    assert inventory["timeout_policy"] == "remaining_budget"
+
+
+def test_openai_fallback_model_inventory_skips_without_model_list():
+    inventory = service._openai_fallback_model_inventory(["fallback-model"], [])
+
+    assert inventory["status"] == "skipped"
+    assert inventory["unknown_fallback_models"] == []
+
+
+@pytest.mark.asyncio
+async def test_search_does_not_cap_primary_timeout_when_fallback_configured(monkeypatch):
+    service.reset_runtime_breakers()
+    monkeypatch.setenv("OPENAI_COMPATIBLE_API_URL", "https://relay.example.com/v1")
+    monkeypatch.setenv("OPENAI_COMPATIBLE_API_KEY", "relay-test-secret")
+    monkeypatch.setenv("OPENAI_COMPATIBLE_MODEL", "primary-model")
+    monkeypatch.setenv("OPENAI_COMPATIBLE_FALLBACK_MODELS", "fallback-model")
+    seen_timeouts = []
+
+    async def fake_search(self, query, platform="", ctx=None):
+        return "Primary answer with https://example.com/source"
+
+    async def fake_wait_for(coro, timeout=None):
+        seen_timeouts.append(timeout)
+        return await coro
+
+    monkeypatch.setattr(service.OpenAICompatibleSearchProvider, "search", fake_search)
+    monkeypatch.setattr(service.asyncio, "wait_for", fake_wait_for)
+
+    result = await service.search("what is example", providers="openai-compatible", timeout_seconds=90)
+
+    assert result["ok"] is True
+    assert result["model"] == "primary-model"
+    assert result["model_fallback_used"] is False
+    assert result["routing_decision"]["openai_compatible_timeout_policy"] == "remaining_budget"
+    assert seen_timeouts
+    assert seen_timeouts[0] >= 80
+    assert any(attempt.get("attempt_timeout_seconds", 0) >= 80 for attempt in result["provider_attempts"])
+
+
+@pytest.mark.asyncio
+async def test_search_gives_fallback_remaining_budget_after_primary_hard_failure(monkeypatch):
+    service.reset_runtime_breakers()
+    monkeypatch.setenv("OPENAI_COMPATIBLE_API_URL", "https://relay.example.com/v1")
+    monkeypatch.setenv("OPENAI_COMPATIBLE_API_KEY", "relay-test-secret")
+    monkeypatch.setenv("OPENAI_COMPATIBLE_MODEL", "primary-model")
+    monkeypatch.setenv("OPENAI_COMPATIBLE_FALLBACK_MODELS", "fallback-model")
+    seen_timeouts = []
+
+    async def fake_search(self, query, platform="", ctx=None):
+        if self.model == "primary-model":
+            raise httpx.HTTPStatusError(
+                "missing",
+                request=httpx.Request("POST", "https://relay.example.com/v1/chat/completions"),
+                response=httpx.Response(503, json={"error": {"code": "model_not_found"}}, request=httpx.Request("POST", "https://relay.example.com/v1/chat/completions")),
+            )
+        return "Fallback answer with https://example.com/source"
+
+    async def fake_wait_for(coro, timeout=None):
+        seen_timeouts.append(timeout)
+        return await coro
+
+    monkeypatch.setattr(service.OpenAICompatibleSearchProvider, "search", fake_search)
+    monkeypatch.setattr(service.asyncio, "wait_for", fake_wait_for)
+
+    result = await service.search("what is example", providers="openai-compatible", timeout_seconds=90)
+
+    assert result["ok"] is True
+    assert result["model"] == "fallback-model"
+    assert result["model_fallback_used"] is True
+    assert len(seen_timeouts) == 2
+    assert seen_timeouts[0] >= 80
+    assert seen_timeouts[1] >= 80
+
+
+@pytest.mark.asyncio
+async def test_diagnose_reports_unknown_fallback_models_without_failing_ok(monkeypatch):
+    monkeypatch.setenv("OPENAI_COMPATIBLE_API_URL", "https://relay.example.com/v1")
+    monkeypatch.setenv("OPENAI_COMPATIBLE_API_KEY", "relay-test-secret")
+    monkeypatch.setenv("OPENAI_COMPATIBLE_MODEL", "grok-4.6")
+    monkeypatch.setenv("OPENAI_COMPATIBLE_FALLBACK_MODELS", "missing-model")
+
+    async def fake_quick(api_url, api_key, model):
+        return {"status": "ok", "message": "chat ok", "response_time_ms": 10, "http_status": 200, "content_type": "application/json", "has_content": True}
+
+    async def fake_probe(api_url, api_key, model, *, stream, timeout_seconds):
+        return {
+            "name": "真实 search 请求 (stream=true)" if stream else "真实 search 请求 (stream=false)",
+            "status": "ok",
+            "message": "ok",
+            "response_time_ms": 10,
+            "http_status": 200,
+            "content_type": "application/json",
+            "has_content": True,
+            "stream": stream,
+        }
+
+    async def fake_models(api_url, api_key):
+        return ["grok-4.6", "grok-4.5"]
+
+    monkeypatch.setattr(service, "_test_primary_chat_completion", fake_quick)
+    monkeypatch.setattr(service, "_probe_openai_compatible_search_shape", fake_probe)
+    monkeypatch.setattr(service, "fetch_available_models", fake_models)
+
+    result = await service.diagnose_openai_compatible(timeout_seconds=5)
+
+    assert result["ok"] is True
+    assert result["timeout_policy"] == "remaining_budget"
+    assert result["fallback_model_inventory"]["unknown_fallback_models"] == ["missing-model"]
+    assert any(check.get("name") == "兜底模型清单" and check.get("status") == "warning" for check in result["checks"])
+    assert "不在上游" in result["recommendation"]
+
+
+@pytest.mark.asyncio
+async def test_doctor_warns_unknown_fallback_models_without_failing_ok(monkeypatch, tmp_path):
+    _reset_config(monkeypatch, tmp_path)
+    monkeypatch.setenv("OPENAI_COMPATIBLE_API_URL", "https://relay.example.com/v1")
+    monkeypatch.setenv("OPENAI_COMPATIBLE_API_KEY", "relay-test-secret")
+    monkeypatch.setenv("OPENAI_COMPATIBLE_MODEL", "grok-4.6")
+    monkeypatch.setenv("OPENAI_COMPATIBLE_FALLBACK_MODELS", "missing-model")
+    monkeypatch.setenv("EXA_API_KEY", "exa-test-secret")
+    monkeypatch.setenv("CONTEXT7_API_KEY", "ctx-test-secret")
+    monkeypatch.setenv("TAVILY_API_KEY", "tavily-test-secret")
+
+    async def fake_main(provider_config):
+        return {
+            "status": "ok",
+            "message": "ok",
+            "available_models": ["grok-4.6"],
+            "models_endpoint_test": {"status": "ok", "available_models": ["grok-4.6"]},
+            "chat_completion_test": {"status": "ok"},
+        }
+
+    async def fake_ok():
+        return {"status": "ok", "message": "ok"}
+
+    monkeypatch.setattr(service, "_safe_test_main_provider_connection", fake_main)
+    monkeypatch.setattr(service, "_test_exa_connection", fake_ok)
+    monkeypatch.setattr(service, "_test_tavily_connection", fake_ok)
+    monkeypatch.setattr(service, "_test_jina_connection", fake_ok)
+    monkeypatch.setattr(service, "_test_zhipu_connection", fake_ok)
+    monkeypatch.setattr(service, "_test_zhipu_mcp_connection", fake_ok)
+    monkeypatch.setattr(service, "_test_context7_connection", fake_ok)
+
+    result = await service.doctor()
+
+    assert result["ok"] is True
+    assert result["openai_compatible_fallback_inventory"]["status"] == "warning"
+    assert result["openai_compatible_fallback_inventory"]["unknown_fallback_models"] == ["missing-model"]
+
+
 def test_anysearch_vertical_status_is_experimental_and_not_minimum_required(monkeypatch):
     monkeypatch.setenv("SMART_SEARCH_MINIMUM_PROFILE", "standard")
     monkeypatch.setenv("OPENAI_COMPATIBLE_API_URL", "https://relay.example.com/v1")


### PR DESCRIPTION
## Summary
- OpenAI-compatible model fallback is now fail-over, not a 30s time slice.
- The active model keeps the remaining `--timeout` budget; a backup model is tried only after a hard failure.
- `doctor` and `diagnose openai-compatible` warn when a configured fallback id is missing from `/models`, without failing a healthy primary path.

## Why
v0.1.15 capped the primary model at `min(30s, remaining/2)` whenever fallback models were configured. Native `grok-4.6` search often needs 25-45s, so it timed out and then failed over to a missing model such as `grok-composer-2.5-fast`.

## Test plan
- [x] `python -m pytest tests -q` (420 passed)
- [x] `python -m smart_search.cli regression`
- [x] `python -m smart_search.cli smoke --mock --format json`
- [ ] After merge: install `0.1.15-beta.2` if published, then tag `v0.1.16`