### PR TITLE
chore(release): bump version to 0.1.17

### DIFF
--- a/.github/releases/v0.1.17.md
+++ b/.github/releases/v0.1.17.md
@@ -1,0 +1,65 @@
+# v0.1.17
+
+Stable release for search reliability, provider compatibility, source
+provenance, and agent integrations.
+
+## What Changed
+
+- Replaced the destructive shared 90-second search timeout with a configurable
+  180-second phase budget. Hybrid routing preserves main-model capacity,
+  provider retries respect the deadline, optional-source timeout retains the
+  primary answer, and results expose phase/partial-success telemetry.
+- Added opt-in OpenAI-compatible Responses API support through
+  `OPENAI_COMPATIBLE_API_MODE=responses`. Chat Completions remains the default.
+  The official typed output/stream subset, citations, terminal failures,
+  breaker isolation, doctor, and diagnose paths are covered.
+- Updated Sciverse to the current v1.0.0 catalog/search/semantic/relations
+  schema. Legacy `--mode` remains as a deprecated bridge to
+  `--retrieval hybrid`.
+- Moved the OpenCode global Skill target to
+  `~/.config/opencode/skills/smart-search-cli` while preserving legacy trees as
+  read-only status metadata.
+- Added structured-first xAI inline URL recovery when response annotations are
+  absent.
+- Added a standalone DeepSeek Harness bundle under
+  `packages/smart-search-dsh`, tested against DSH `0.1.1-rc.2`.
+
+The DSH bundle is present in the GitHub source release but is not included in
+the core npm package and is not yet published as
+`@konbakuyomu/smart-search-dsh`.
+
+## Upgrade
+
+```powershell
+mise use -g "npm:@konbakuyomu/smart-search@0.1.17" -y --pin
+mise reshim
+smart-search --version
+smart-search skills update --targets codex,claude --format json
+smart-search doctor --format json
+```
+
+Expected version after publish: `smart-search 0.1.17` from npm `latest`.
+
+## Validation
+
+- Integrated source/package suite: 487 passed.
+- CLI regression: 331 passed.
+- GitHub CI: Ubuntu Node 18/Python 3.10, Ubuntu Node 24/Python 3.12,
+  Windows Node 22/Python 3.12.
+- Packed-tarball install, wrapper repair, mock smoke, 9-file Skill parity,
+  compile/import, secret, conflict, and diff checks passed.
+- Live acceptance passed for timeout stream/non-stream, named-relay Chat and
+  Responses stream/non-stream, Sciverse catalog/search/semantic/relations,
+  OpenCode 1.18.25 Skill discovery, and DSH adapter search/fetch.
+- Registry canary `0.1.16-beta.2` passed install and live search with the new
+  180-second phase telemetry before this stable promotion.
+
+## Compatibility Notes
+
+- `OPENAI_COMPATIBLE_API_MODE` defaults to `chat-completions`; enable
+  `responses` only for a relay that implements the tested subset.
+- `SMART_SEARCH_TIMEOUT_SECONDS` defaults to 180; an explicit `--timeout`
+  remains the one-call override.
+- fastCRW PR #15 was not adopted because its current endpoint/auth/envelope,
+  retry, routing, packaging, security, maintenance, conflict, and CI gates did
+  not match the current upstream/project contracts.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@konbakuyomu/smart-search",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@konbakuyomu/smart-search",
-      "version": "0.1.16",
+      "version": "0.1.17",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@konbakuyomu/smart-search",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "description": "CLI-first multi-source web research with xAI/OpenAI-compatible search, Exa, Context7, Zhipu, Tavily, Firecrawl, and Deep Research planning.",
   "license": "MIT",
   "homepage": "https://github.com/konbakuyomu/smartsearch#readme",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "smart-search"
-version = "0.1.16"
+version = "0.1.17"
 description = "CLI-first multi-source web research with xAI/OpenAI-compatible search, Exa, Context7, Zhipu, Tavily, Firecrawl, and Deep Research planning."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

- bump core package, lockfile, and Python metadata to `0.1.17`;
- add stable release notes for the search reliability and integration backlog;
- keep the standalone DSH package at `0.1.0`; it is not part of the core npm tarball.

## Validation

- full pytest / npm test: 487 passed
- packed-tarball install smoke: passed
- Skill parity: 9 files
- DSH package tests: 16 passed
- DSH archive contract: passed
- `git diff --check`: passed
- registry canary `0.1.16-beta.2`: installed and passed live search with the 180-second phase budget

## Release sequence

After this PR merges, the branch-push publish workflow must detect the stable bump and skip automatic beta publication. The signed release action is triggered only by pushing tag `v0.1.17`, which publishes npm `latest` and creates/updates the GitHub release.